### PR TITLE
utils/construct_checksum should handle 'module' or 'function' being None.

### DIFF
--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -24,8 +24,8 @@ def construct_checksum(level=logging.ERROR, class_name='', traceback='', message
     if 'data' in kwargs and kwargs['data'] and '__sentry__' in kwargs['data'] and 'frames' in kwargs['data']['__sentry__']:
         frames = kwargs['data']['__sentry__']['frames']
         for frame in frames:
-            checksum.update(frame['module'])
-            checksum.update(frame['function'])
+            checksum.update(frame['module'] or '')
+            checksum.update(frame['function'] or '')
 
     elif traceback:
         traceback = '\n'.join(traceback.split('\n')[:-3])


### PR DESCRIPTION
utils/construct_checksum should handle 'module' or 'function' being None.

This happens for example in a genshi template and I guess some other weird cases where there's no real module
