### PR TITLE
SentryHandler instantiates a Client objet from args and kwargs in case a 

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -12,6 +12,7 @@ This document describes configuration options available to Sentry.
    celery
    django
    flask
+   pylons
    logging
    logbook
    wsgi

--- a/docs/config/pylons.rst
+++ b/docs/config/pylons.rst
@@ -1,0 +1,48 @@
+Configuring Pylons
+==================
+
+Logger setup
+------------
+
+Add the following lines to your project's `.ini` file to setup `SentryHandler`:
+
+.. code-block:: ini
+
+    [loggers]
+    keys = root, sentry
+
+    [handlers]
+    keys = console, sentry
+
+    [formatters]
+    keys = generic
+
+    [logger_root]
+    level = INFO
+    handlers = console, sentry
+
+    [logger_sentry]
+    level = WARN
+    handlers = console
+    qualname = sentry.errors
+    propagate = 0
+
+    [handler_console]
+    class = StreamHandler
+    args = (sys.stderr,)
+    level = NOTSET
+    formatter = generic
+
+    [handler_sentry]
+    class = raven.handlers.logging.SentryHandler
+    args = (['http://sentry.local/store/'], 'KEY')
+    level = NOTSET
+    formatter = generic
+
+    [formatter_generic]
+    format = %(asctime)s,%(msecs)03d %(levelname)-5.5s [%(name)s] %(message)s
+    datefmt = %H:%M:%S
+
+.. note:: You may want to setup other loggers as well.
+
+

--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -12,9 +12,21 @@ import logging
 import sys
 import traceback
 
+from raven.base import Client
+
+
 class SentryHandler(logging.Handler):
-    def __init__(self, client=None):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        if len(args) == 1:
+            self.client = args[0]
+        elif 'client' in kwargs:
+            self.client = kwargs['client']
+        elif len(args) == 2 and not kwargs:
+            servers, key = args
+            self.client = Client(servers=servers, key=key)
+        else:
+            self.client = Client(*args, **kwargs)
+
         logging.Handler.__init__(self)
 
     def emit(self, record):

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -77,3 +77,14 @@ class LoggingHandlerTest(TestCase):
         self.assertEquals(event['message'], 'This is a test of no stacks')
         self.assertTrue('__sentry__' in event['data'])
         self.assertFalse('frames' in event['data']['__sentry__'])
+
+    def test_init(self):
+        client = TempStoreClient(include_paths=['tests'])
+        handler = SentryHandler(client)
+        assert handler.client == client
+
+        handler = SentryHandler(client=client)
+        assert handler.client == client
+
+        handler = SentryHandler(['http://sentry.local/store/'], 'KEY')
+        assert handler.client


### PR DESCRIPTION
SentryHandler instantiates a Client objet from args and kwargs in case a client is not passed explicitly.

Moreover, if exactly 2 positional arguments are passed, the first is treated as the list of server urls, and the second as the key.

Also, an example configuration for Pylons is added to the documentation.
