### PR TITLE
Invert the direction of the auto-log traces so they match those given by Exceptions and culprit determination works properly. 

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -123,6 +123,7 @@ class Client(object):
                         else:
                             continue
                     stack.append(frame)
+                stack.reverse()
             else:
                 # assume stack was a list of frames
                 stack = get_stack or []


### PR DESCRIPTION
When using SENTRY_AUTO_LOG_STACKS the resulting traces in Sentry are bottom-to-top whereas the traces from an exception are top-to-bottom. This is not only very confusing, but it causes Sentry to identify the WSGI handler as the cause of all errors in logging statements.
