### PR TITLE
Patch for non-django user objects

### DIFF
--- a/raven/contrib/django/__init__.py
+++ b/raven/contrib/django/__init__.py
@@ -21,7 +21,7 @@ class DjangoClient(Client):
     def __init__(self, servers=None, **kwargs):
         super(DjangoClient, self).__init__(servers=servers, **kwargs)
 
-    def get_user_info(request):
+    def get_user_info(self, request):
         if request.user.is_authenticated():
             user_info = {
                 'is_authenticated': True,


### PR DESCRIPTION
Hey David,

I upgraded sentry at some point and started having issues with sentry + our auth system. We use request.user = None for anonymous users among other things. This allows use to subclass the django client, and override a method to get things working again. If you want tests, I'll try to come up with some. Not sure they're necessary in this case, though.

Joseph
