### PR TITLE
Add SENTRY_SITE_NAME config variable for flask applications

### DIFF
--- a/raven/contrib/flask/__init__.py
+++ b/raven/contrib/flask/__init__.py
@@ -48,6 +48,7 @@ class Sentry(object):
                 servers=app.config.get('SENTRY_SERVERS'),
                 name=app.config.get('SENTRY_NAME'),
                 key=app.config.get('SENTRY_KEY'),
+                site=app.config.get('SENTRY_SITE_NAME'),
             )
         else:
             client = self.client


### PR DESCRIPTION
Hi,

I added the config variable SENTRY_SITE_NAME to set the site for the application, without it is very difficult to different multiple Flask sites in one sentry instance. 

Best regards
