### PR TITLE
This fix a time shift in sentry when machines are in different time zone

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -185,7 +185,7 @@ class Client(object):
         kwargs['data'] = transform(data)
 
         if 'timestamp' not in kwargs:
-            kwargs['timestamp'] = datetime.datetime.utcnow()
+            kwargs['timestamp'] = str(datetime.datetime.utcnow()) + " UTC"
 
         self.send(**kwargs)
 


### PR DESCRIPTION
This is due to the fact that datetime.datetime.utcnow() does not add a "UTC" or "00:00" at the end .
