### PR TITLE
AsyncClient should accept args/kwargs.

### DIFF
--- a/raven/contrib/async.py
+++ b/raven/contrib/async.py
@@ -18,12 +18,13 @@ class AsyncClient(Client):
     """This client uses a single background thread to dispatch errors."""
     _terminator = object()
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """Starts the task thread."""
         self.queue = Queue(-1)
         self._lock = Lock()
         self._thread = None
         self.start()
+        super(AsyncClient, self).__init__(*args, **kwargs)
 
     def main_thread_terminated(self):
         size = self.queue.qsize()


### PR DESCRIPTION
I came into the error where an unexpected kwarg (string_max_length) was
being passed to AsyncClient; so it should accept those params.
