### PR TITLE
SentryHandler needs to mixin object

### DIFF
--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -16,7 +16,7 @@ import traceback
 from raven.base import Client
 
 
-class SentryHandler(logging.Handler):
+class SentryHandler(logging.Handler, object):
     reserved = ['threadName', 'name', 'thread', 'created', 'process', 'processName', 'args', 'module',
                 'filename', 'levelno', 'exc_text', 'pathname', 'lineno', 'msg', 'exc_info', 'funcName',
                 'relativeCreated', 'levelname', 'msecs', 'data', 'stack', 'message']


### PR DESCRIPTION
This fixes an error in raven.contrib.django.handlers.SentryHandler when
calling super().

At this point, SentryHandler is an old style Python class, 'classobj'
instead of 'type'. super() only works on new style 'type's, so we need
to mixin object to make it work.
