### PR TITLE
Fixing ValueError: too many values to unpack

### DIFF
--- a/raven/utils/stacks.py
+++ b/raven/utils/stacks.py
@@ -52,7 +52,7 @@ def get_lines_from_file(filename, lineno, context_lines, loader=None, module_nam
         except (OSError, IOError):
             pass
     if source is None:
-        return None, [], None, []
+        return None, [], None
 
     encoding = 'ascii'
     for line in source[:2]:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/deploy/.virtualenvs/pound/src/sterling/sterling/logging/sentry/handlers.py", line 40, in emit
    return self._emit(record)
  File "/home/deploy/.virtualenvs/pound/src/sterling/sterling/logging/sentry/handlers.py", line 81, in _emit
    data=data, extra=extra, date=date, **kwargs)
  File "/home/deploy/.virtualenvs/pound/src/raven/raven/base.py", line 187, in capture
    'frames': varmap(shorten, get_stack_info(frames))
  File "/home/deploy/.virtualenvs/pound/src/raven/raven/utils/stacks.py", line 172, in get_stack_info
    pre_context, context_line, post_context = get_lines_from_file(abs_path, lineno, 3, loader, module_name)
ValueError: too many values to unpack
```

Yell out if you'd like a unit test.
