### PR TITLE
Bug using init_app to set the app instead of doing it in __init__ in Flask

### DIFF
--- a/raven/contrib/flask/__init__.py
+++ b/raven/contrib/flask/__init__.py
@@ -34,7 +34,7 @@ class Sentry(object):
     """
     def __init__(self, app=None, client=None, client_cls=Client, dsn=None,
                  logging=False):
-        self.app = app
+        #self.app = app
         self.client_cls = client_cls
         self.dsn = dsn
         self.logging = logging
@@ -74,6 +74,7 @@ class Sentry(object):
         return _handle_exception
 
     def init_app(self, app):
+        self.app = app
         if self.logging:
             setup_logging(SentryHandler(self.client))
         got_request_exception.connect(self.handle_exception(self.client), sender=app, weak=False)


### PR DESCRIPTION
I have a large Flask application and I need to use the init_app method to set the app object to global application variables. I found that this doesn't work with your sentry client, because the **init** method saves the app object in self.app, but the init_app doesn't. I just added the assigment in init_app and it works. I also suggest to delete the assigment in the **init** method.
