### PR TITLE
Raven defaults to sending more data when called via python logging and extra data is easier to send

### DIFF
--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -97,7 +97,7 @@ class SentryHandler(logging.Handler, object):
         extra = getattr(record, 'data', {})
         # Add in all of the data from the record that we aren't already capturing
         for k in record.__dict__.keys():
-            if k in ('stack', 'name', 'args', 'msg', 'levelno', 'exc_text', 'exc_info', 'data'):
+            if k in ('stack', 'name', 'args', 'msg', 'levelno', 'exc_text', 'exc_info', 'data', 'created', 'levelname', 'msecs', 'relativeCreated'):
                 continue
             extra[k] = record.__dict__[k]
 


### PR DESCRIPTION
```
Prior to this commit extra data that we wanted to pass in to sentry from the python loggin client would have to look like this:
    logger.info("This is message %d of %d", 1, 1, extra={'data':{'my extra data':'This is whatever I want it to be'}})

This is because python's logging system will take whatever the contents of 'extra' are and attach each item to the record like this:
        if extra is not None:
            for key in extra:
                if (key in ["message", "asctime"]) or (key in rv.__dict__):
                    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
                rv.__dict__[key] = extra[key]

Then raven, when it gets to handle the message, looks only for record.extra. Therefore in order to get the extra data in one needed to use a dictionary in a dictionary.

This change makes raven use any extra data on the record so that the above message can become:
    logger.info("This is message %d of %d", 1, 1, extra={'my extra data':'This is whatever I want it to be'})

It also has the added benefit of including other data that is on the record object but not normally passed to sentry. This includes the following:

thread: -1216764224
threadName: MainThread
processName: MainProcess
module: 'log_test'
filename: log_test.py
lineno: 44
```
