### PR TITLE
Correcting processor example to filter POST bodies, too

### DIFF
--- a/raven/processors.py
+++ b/raven/processors.py
@@ -51,7 +51,7 @@ class SanitizePasswordsProcessor(Processor):
             frame['vars'] = varmap(self.sanitize, frame['vars'])
 
     def filter_http(self, data):
-        for n in ('data', 'cookies', 'headers', 'env'):
+        for n in ('body', 'cookies', 'headers', 'env'):
             if n not in data:
                 continue
 


### PR DESCRIPTION
Adding 'body' to filter_http in the example raven SanitizePasswordsProcessor.
