### PR TITLE
Use updated Celery imports

### DIFF
--- a/raven/contrib/celery/__init__.py
+++ b/raven/contrib/celery/__init__.py
@@ -6,7 +6,10 @@ raven.contrib.celery
 :license: BSD, see LICENSE for more details.
 """
 
-from celery.decorators import task
+try:
+    from celery.task import task
+except ImportError:
+    from celery.decorators import task
 from raven.base import Client
 
 


### PR DESCRIPTION
Newer versions of Celery want you to import the task decorator from 'celery.task' instead of 'celery.decorators'.
