### PR TITLE
Import Celery task decorator from celery.task

### DIFF
--- a/raven/contrib/django/celery/__init__.py
+++ b/raven/contrib/django/celery/__init__.py
@@ -8,8 +8,10 @@ raven.contrib.django.celery
 
 from raven.contrib.celery import CeleryMixin
 from raven.contrib.django import DjangoClient
-from celery.decorators import task
-
+try:
+    from celery.task import task
+except ImportError:
+    from celery.decorators import task
 
 class CeleryClient(CeleryMixin, DjangoClient):
     def send_integrated(self, kwargs):


### PR DESCRIPTION
Missed this in my last pull request.
