### PR TITLE
Fix 2 failing tests that don't account for __file__ can be .pyc instead of .py 

### DIFF
--- a/tests/client/tests.py
+++ b/tests/client/tests.py
@@ -174,7 +174,7 @@ class ClientTest(TestCase):
         frames = event['sentry.interfaces.Stacktrace']
         self.assertEquals(len(frames['frames']), 1)
         frame = frames['frames'][0]
-        self.assertEquals(frame['abs_path'], __file__)
+        self.assertEquals(frame['abs_path'], __file__.replace('.pyc', '.py'))
         self.assertEquals(frame['filename'], 'tests/client/tests.py')
         self.assertEquals(frame['module'], __name__)
         self.assertEquals(frame['function'], 'test_exception_event')

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -73,4 +73,4 @@ class ServerTest(TestCase):
         self.assertEquals(frame['function'], 'test_exception')
         self.assertEquals(frame['module'], __name__)
         self.assertEquals(frame['filename'], 'tests/integration/tests.py')
-        self.assertEquals(frame['abs_path'], __file__)
+        self.assertEquals(frame['abs_path'], __file__.replace('.pyc', '.py'))


### PR DESCRIPTION
Fixes GH-92.
