### PR TITLE
Hack to prevent stupid "TypeError: 'NoneType' object is not callable" error on exit of `python setup.py test`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,15 @@ Django, and Flask. Raven also includes drop-in support for any WSGI-compatible
 web application.
 """
 
+# Hack to prevent stupid "TypeError: 'NoneType' object is not callable" error
+# in multiprocessing/util.py _exit_function when running `python
+# setup.py test` (see
+# http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html)
+try:
+    import multiprocessing
+except ImportError:
+    pass
+
 from setuptools import setup, find_packages
 
 tests_require = [


### PR DESCRIPTION
Hack to prevent stupid `TypeError: 'NoneType' object is not callable` error on exit of `python setup.py test`
in `multiprocessing/util.py` `_exit_function` when running `python setup.py test` (see
http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html)
