### PR TITLE
Add test for parsing DSN with invalid scheme. Gets coverage of `raven.conf` from 97% to 100%.

### DIFF
--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -108,6 +108,10 @@ class LoadTest(TestCase):
         dsn = 'https://bar@example.com'
         self.assertRaises(ValueError, load, dsn)
 
+    def test_invalid_scheme(self):
+        dsn = 'ftp://foo:bar@sentry.local/1'
+        self.assertRaises(ValueError, load, dsn)
+
 
 class SetupLoggingTest(TestCase):
     def test_basic_not_configured(self):


### PR DESCRIPTION
Before:

``` shell
$ nosetests --with-coverage --cover-package=raven 2>&1 | grep '^raven.conf '
raven.conf                       31      1    97%   33
```

After:

``` shell
$ nosetests --with-coverage --cover-package=raven 2>&1 | grep '^raven.conf '
raven.conf                       31      0   100%
```
