### PR TITLE
Fix bad port handling in UDP DSNs

### DIFF
--- a/raven/conf/__init__.py
+++ b/raven/conf/__init__.py
@@ -32,7 +32,7 @@ def load(dsn, scope=None):
     if url.scheme not in ('http', 'https', 'udp'):
         raise ValueError('Unsupported Sentry DSN scheme: %r' % url.scheme)
     netloc = url.hostname
-    if (url.scheme == 'http' and url.port and url.port != 80) or (url.scheme == 'https' and url.port and url.port != 443):
+    if url.port and (url.scheme, url.port) not in (('http', 80), ('https', 443)):
         netloc += ':%s' % url.port
     path_bits = url.path.rsplit('/', 1)
     if len(path_bits) > 1:

--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -96,9 +96,12 @@ class LoadTest(TestCase):
         dsn = 'udp://foo:bar@sentry.local:9001/1'
         res = {}
         load(dsn, res)
-        self.assertEqual('1', res['SENTRY_PROJECT'])
-        self.assertEqual('foo', res['SENTRY_PUBLIC_KEY'])
-        self.assertEqual('bar', res['SENTRY_SECRET_KEY'])
+        self.assertEquals(res, {
+            'SENTRY_PROJECT': '1',
+            'SENTRY_SERVERS': ['udp://sentry.local:9001/api/store/'],
+            'SENTRY_PUBLIC_KEY': 'foo',
+            'SENTRY_SECRET_KEY': 'bar',
+        })
 
     def test_missing_netloc(self):
         dsn = 'https://foo:bar@/1'


### PR DESCRIPTION
This was broken in b8ec5cef83a073796dc3fcde52dbb723951c96d9.
