### PR TITLE
slightly improve raven test to realize it failed on errors

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -73,6 +73,9 @@ class ClientState(object):
         self.last_check = None
         self.retry_number = 0
 
+    def did_fail(self):
+        return self.status == self.ERROR
+
 
 class Client(object):
     """

--- a/raven/scripts/runner.py
+++ b/raven/scripts/runner.py
@@ -60,6 +60,11 @@ def main():
             'loadavg': os.getloadavg(),
         }
     ))
+
+    if client.state.did_fail():
+        print 'error!'
+        return False
+
     print 'success!'
     print
     print 'The test message can be viewed at the following URL:'


### PR DESCRIPTION
Right now if you run "raven test http://foo:bar@baz/default", it will think it succeeded while printing a stacktrace. This can be problematic as you may not notice the top of the output, and think the test succeeded, making the point of the test a bit contrary. Here's a simple functional example, though it also happens with for other types of errors, such as if the host is real but Sentry isn't running, or if the secret is wrong:

```
Using DSN configuration:
  http://foo:bar@baz/default

Client configuration:
  servers        : ['http://baz/api/store/']
  project        : default
  public_key     : foo
  secret_key     : bar

Unable to reach Sentry log server: <urlopen error [Errno 8] nodename nor servname provided, or not known> (url: http://baz/api/store/)
Traceback (most recent call last):
  File "/Library/Python/2.6/site-packages/raven-1.7.6-py2.6.egg/raven/base.py", line 350, in send_remote
    self._send_remote(url=url, data=data, headers=headers)
  File "/Library/Python/2.6/site-packages/raven-1.7.6-py2.6.egg/raven/base.py", line 331, in _send_remote
    return self.send_http(url, data, headers)
  File "/Library/Python/2.6/site-packages/raven-1.7.6-py2.6.egg/raven/base.py", line 389, in send_http
    response = urllib2.urlopen(req, data).read()
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/urllib2.py", line 124, in urlopen
    return _opener.open(url, data, timeout)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/urllib2.py", line 383, in open
    response = self._open(req, data)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/urllib2.py", line 401, in _open
    '_open', req)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/urllib2.py", line 361, in _call_chain
    result = func(*args)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/urllib2.py", line 1141, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/urllib2.py", line 1116, in do_open
    raise URLError(err)
URLError: <urlopen error [Errno 8] nodename nor servname provided, or not known>
Failed to submit message: 'This is a test message generated using ``raven test``'
Sending a test message... success!

The test message can be viewed at the following URL:
  http://baz/default/search/?q=74cc66c18601498397ff506e05cc1e32$b8a6fbd29cc9113a149ad62cf7e0ddd5
```

This patch at least makes the output instead end with:

```
Sending a test message... error!
```

There's likely a better way, but I at least wanted to give it a shot.
