### PR TITLE
send celery log messages >=ERROR to sentry

### DIFF
--- a/raven/contrib/celery/__init__.py
+++ b/raven/contrib/celery/__init__.py
@@ -31,7 +31,7 @@ class CeleryClient(CeleryMixin, Client):
 
 class CeleryFilter(object):
     def filter(self, record):
-        if record.funcName in ('_log_error'):
+        if record.funcName in ('_log_error',):
             return 0
         else:
             return 1


### PR DESCRIPTION
Custom filter since celery.worker.job.Request._log_error will also log the error to the logging subsystem
