### PR TITLE
Asynchronous HTTP transports for Twisted and Tornado

### DIFF
--- a/raven/transport.py
+++ b/raven/transport.py
@@ -15,6 +15,12 @@ try:
 except:
     twisted = False
 
+try:
+    from tornado.httpclient import AsyncHTTPClient
+    tornado = True
+except:
+    tornado = False
+
 
 class InvalidScheme(ValueError):
     """
@@ -208,6 +214,25 @@ class TwistedHTTPTransport(HTTPTransport):
         d = getPage(self._url, method='POST', postdata=data, headers=headers)
 
 
+class TornadoHTTPTransport(HTTPTransport):
+
+    scheme = ['tornado+http']
+
+    def __init__(self, parsed_url):
+        if not tornado:
+            raise ImportError('TornadoHTTPTransport requires tornado.')
+
+        super(TornadoHTTPTransport, self).__init__(parsed_url)
+
+        # remove the tornado+ from the protocol, as it is not a real protocol
+        self._url = self._url.split('+', 1)[-1]
+
+    def send(self, data, headers):
+        client = AsyncHTTPClient()
+        client.fetch(self._url, callback=None,
+                     method='POST', headers=headers, body=data)
+
+
 class TransportRegistry(object):
     def __init__(self, transports=None):
         # setup a default list of senders
@@ -255,5 +280,6 @@ default_transports = [
     HTTPTransport,
     GeventedHTTPTransport,
     TwistedHTTPTransport,
+    TornadoHTTPTransport,
     UDPTransport,
 ]


### PR DESCRIPTION
ehlo dcramer,

I've added two asynchronous non-blocking clients for Twisted and Tornado. The plain HTTPTransport was a no-go for us because it could block - something really undesirable in a single-threaded high-load production environment.

I did my best to keep the commits as simple as possible, but as the number of transport grows, transports.py could use some refactoring/cleanup - at your discretion. Also, the documentation doesn't mention the extra transport - it would be great to be able to find them without grepping through code. ;-)

We'll be using these transport in production environment soon - I'll let you know if any bugs pop up.

Kosma
