### PR TITLE
Add ability to capture explicit exceptions

### DIFF
--- a/raven/events.py
+++ b/raven/events.py
@@ -14,7 +14,7 @@ from raven.utils.encoding import shorten, to_unicode
 from raven.utils.stacks import get_stack_info, iter_traceback_frames, \
                                get_culprit
 
-__all__ = ('BaseEvent', 'Exception', 'Message', 'Query')
+__all__ = ('BaseEvent', 'Exception', 'Message', 'Query', 'ExplicitException')
 
 
 class BaseEvent(object):
@@ -99,6 +99,30 @@ class Exception(BaseEvent):
             },
         }
 
+class ExplicitException(Exception):
+    """
+    ExplicitExceptions are similar to Exceptions but expect errors in dict form rather than exc_info.
+
+    ExplicitExceptions ensure the data is valid.
+
+    """
+    def capture(self, error, **kwargs):
+        if (
+                error.has_key('message') and
+                error.has_key('culprit') and
+                error.has_key('server_name') and
+                error.has_key('sentry.interfaces.Stacktrace') and
+                error['sentry.interfaces.Stacktrace'].__class__ == dict and
+                error['sentry.interfaces.Stacktrace'].has_key('frames') and
+                error['sentry.interfaces.Stacktrace']['frames'].__class__ == list and
+                error.has_key('sentry.interfaces.Exception') and
+                error['sentry.interfaces.Exception'].__class__ == dict and
+                error.has_key('site') and
+                error.has_key('timestamp')
+            ):
+            return error
+        else:
+            raise ValueError('Malformed exception')
 
 class Message(BaseEvent):
     """

--- a/tests/client/tests.py
+++ b/tests/client/tests.py
@@ -223,6 +223,36 @@ class ClientTest(TestCase):
         self.assertEquals(frame['function'], 'test_exception_event')
         self.assertTrue('timestamp' in event)
 
+    def test_explicit_exception_event(self):
+        error = {
+                "message": "ZeroDivisionError: integer division or modulo by zero",
+                "culprit": "__main__.err",
+                "server_name": "leap.local",
+                "sentry.interfaces.Stacktrace": {
+                    "frames": [{
+                        "function": "err",
+                        "abs_path": "<ipython-input-4-3cbe8b3c426f>",
+                        "vars": {},
+                        "module": "__main__",
+                        "filename": "ipython-input-4-3cbe8b3c426f>", "lineno": 3
+                    }]
+                },
+                "sentry.interfaces.Exception": {
+                    "type": "ZeroDivisionError",
+                    "value": "integer division or modulo by zero",
+                    "module": "exceptions"
+                },
+                "site": None,
+                "timestamp": "2012-06-19T17:01:25Z",
+        }
+
+        self.client.capture('ExplicitException', error=error)
+        self.assertEquals(len(self.client.events), 1)
+        event = self.client.events.pop(0)
+        self.assertEquals(event['message'], 'ZeroDivisionError: integer division or modulo by zero')
+        self.assertTrue('sentry.interfaces.Stacktrace' in event)
+        self.assertTrue('timestamp' in event)
+
     def test_message_event(self):
         self.client.capture('Message', message='test')
 


### PR DESCRIPTION
This pull request adds the ability to capture explicit exceptions.

It adds a new event type, ExplicitException, whose capture event merely validates the data sent to it.

The reason to have this new event type is to send exceptions to Sentry captured on different machines.

One use-case is to collect exceptions via a Python API captured from a Javascript Client app.
