### PR TITLE
Add --data option to 'raven test' to use custom message data.

### DIFF
--- a/raven/scripts/runner.py
+++ b/raven/scripts/runner.py
@@ -12,16 +12,30 @@ import logging
 import os
 import sys
 import pwd
+import json
+from optparse import OptionParser
 
 from raven import Client
 
+def store_json(option, opt_str, value, parser):
+    try:
+        value = json.loads(value)
+    except ValueError:
+        print "Invalid was used for option %s.  Received: %s" % (opt_str, value)
+        sys.exit(1)
+    setattr(parser.values, option.dest, value)
 
 def main():
     root = logging.getLogger('sentry.errors')
     root.setLevel(logging.DEBUG)
     root.addHandler(logging.StreamHandler())
 
-    dsn = ' '.join(sys.argv[2:]) or os.environ.get('SENTRY_DSN')
+    parser = OptionParser()
+    parser.add_option("--data", action="callback", callback=store_json,
+                      type="string", nargs=1, dest="data")
+    (opts, args) = parser.parse_args()
+
+    dsn = ' '.join(args[1:]) or os.environ.get('SENTRY_DSN')
     if not dsn:
         print "Error: No configuration detected!"
         print "You must either pass a DSN to the command, or set the SENTRY_DSN environment variable."
@@ -45,7 +59,7 @@ def main():
     print 'Sending a test message...',
     ident = client.get_ident(client.captureMessage(
         message='This is a test message generated using ``raven test``',
-        data={
+        data=opts.data or {
             'culprit': 'raven.scripts.runner',
             'logger': 'raven.test',
             'sentry.interfaces.Http': {


### PR DESCRIPTION
I wanted an easy way to see how Sentry would react to changes in the data format.

This makes it easier to do something like `raven test --data '{"sentry.interfaces.User": {"is_authenticated": true, "battle": "toads"}}'` and then confirm that it's displaying on Sentry as expected.

I can add docs for this if it seems useful to others.
