### PR TITLE
flask: Use a weakref to hold onto the Sentry object when connecting to flask's got_request_exception signal

### DIFF
--- a/raven/contrib/flask/__init__.py
+++ b/raven/contrib/flask/__init__.py
@@ -93,7 +93,7 @@ class Sentry(object):
         if self.logging:
             setup_logging(SentryHandler(self.client))
 
-        got_request_exception.connect(self.handle_exception, sender=app, weak=False)
+        got_request_exception.connect(self.handle_exception, sender=app)
 
     def captureException(self, *args, **kwargs):
         assert self.client, 'captureException called before application configured'


### PR DESCRIPTION
This makes the garbage collector unable to reclaim the memory used by a Flask app.

Test case:

``` python
import gc
from flask import Flask
from raven.contrib.flask import Sentry


def create_app():
  app = Flask(__name__)
  Sentry(app)
  return app

for i in range(100):
  create_app()
  gc.collect()
```

The memory should stay stable, but it keeps growing because the signal stays connected.
