### PR TITLE
SentryHandler doesn't have its own Log Level

### DIFF
--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -40,7 +40,7 @@ class SentryHandler(logging.Handler, object):
         else:
             self.client = client(*args, **kwargs)
 
-        logging.Handler.__init__(self)
+        logging.Handler.__init__(self, level=kwargs.get('level', logging.NOTSET))
 
     def emit(self, record):
         # from sentry.client.middleware import SentryLogMiddleware

--- a/tests/handlers/logging/tests.py
+++ b/tests/handlers/logging/tests.py
@@ -196,3 +196,11 @@ class LoggingHandlerTest(TestCase):
 
     def test_invalid_first_arg_type(self):
         self.assertRaises(ValueError, SentryHandler, object)
+
+    def test_logging_level_set(self):
+        handler = SentryHandler('http://public:secret@example.com/1', level="ERROR")
+        self.assertEquals(handler.level, logging.ERROR)
+
+    def test_logging_level_set(self):
+        handler = SentryHandler('http://public:secret@example.com/1')
+        self.assertEquals(handler.level, logging.NOTSET)


### PR DESCRIPTION
As a `Handler` class, `SentryHandler` should allow the user to set its log level. This allows SentryHandler to send/not send the logs while respecting the global LogLevel defined at the root level.
