### PR TITLE
Updated documentation for "Configuring logging"

### DIFF
--- a/docs/config/logging.rst
+++ b/docs/config/logging.rst
@@ -51,7 +51,7 @@ Another option is to use :mod:`logging.config.dictConfig`::
 
         'loggers': {
             '': {
-                'handlers': ['console', 'file', 'sentry'],
+                'handlers': ['console', 'sentry'],
                 'level': 'DEBUG',
                 'propagate': False,
                 },


### PR DESCRIPTION
Added notes how to use default logging dictConfig parser to set up sentry.
