### PR TITLE
Updated documentation for "Configuring logging" 

### DIFF
--- a/docs/config/logging.rst
+++ b/docs/config/logging.rst
@@ -45,7 +45,7 @@ Another option is to use :mod:`logging.config.dictConfig`::
             'sentry': {
                 'level': 'ERROR',
                 'class': 'raven.handlers.logging.SentryHandler',
-                'dsn': 'http://public:secret@sentry.aurumsocial.com:9000/9',
+                'dsn': 'http://public:secret@example.com/1',
                 },
             },
 


### PR DESCRIPTION
Added notes how to use default logging dictConfig parser to set up sentry.
