### PR TITLE
Added information that it's possible to use different http transporters.

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -68,6 +68,7 @@ It is composed of six important pieces:
 
 * The project ID which the authenticated user is bound to.
 
+.. note:: Protocol may also contain transporter type: gevent+http, gevent+https, twisted+http, tornado+http
 
 Client Arguments
 ----------------


### PR DESCRIPTION
It's sort of hidden functionality that is very useful.  For example default transporter for http locks twisted loop while sending messages so changing transporter fixes that.

It could get more documentation about existing transporters, but it's best option in short time range I have right now. 
