### PR TITLE
Use simplejson instead of built-in json module

### DIFF
--- a/raven/scripts/runner.py
+++ b/raven/scripts/runner.py
@@ -12,7 +12,7 @@ import logging
 import os
 import sys
 import pwd
-import json
+import simplejson as json
 from optparse import OptionParser
 
 from raven import Client


### PR DESCRIPTION
Python <2.6 doesn't come with a json module.
simplejson is already a requirement, so use it here as well.

This should fix issue #162
