### PR TITLE
DeprecationWarning fix

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -23,7 +23,8 @@ import raven
 from raven.conf import defaults
 from raven.utils import json, varmap, get_versions, get_auth_header
 
-from raven.utils.encoding import transform, shorten, to_string
+from raven.utils.encoding import shorten, to_string
+from raven.utils.serializers import transform
 from raven.utils.stacks import get_stack_info, iter_stack_frames, \
   get_culprit
 from raven.transport.registry import TransportRegistry, default_transports

--- a/raven/utils/stacks.py
+++ b/raven/utils/stacks.py
@@ -10,7 +10,7 @@ import inspect
 import re
 import sys
 
-from raven.utils.encoding import transform
+from raven.utils.serializer import transform
 
 _coding_re = re.compile(r'coding[:=]\s*([-\w.]+)')
 

--- a/tests/utils/encoding/tests.py
+++ b/tests/utils/encoding/tests.py
@@ -4,7 +4,8 @@ import uuid
 
 from unittest2 import TestCase
 
-from raven.utils.encoding import transform, shorten
+from raven.utils.encoding import shorten
+from raven.utils.serializer import transform
 
 
 class TransformTest(TestCase):


### PR DESCRIPTION
Small factor to use raven.utils.serializers.transform rather than raven.utils.encoding.transform, hopefully should fix a bunch of DeprecationWarning's, notable the below one

raven/utils/encoding.py:59: DeprecationWarning: You should switch to raven.utils.serializers.transform
