### PR TITLE
Removing markdown version of readme with incorrect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-THIS PROJECT HAS BEEN MOVED
-
-https://github.com/getsentry/raven-python


### PR DESCRIPTION
README.rst is the correct version, markdown takes precedence over restructured text causing a silly version to be displayed on github (which links to its self, heh).
