### PR TITLE
Twisted-transport should support HTTPS as well

### DIFF
--- a/raven/transport/base.py
+++ b/raven/transport/base.py
@@ -203,7 +203,7 @@ class GeventedHTTPTransport(HTTPTransport):
 
 class TwistedHTTPTransport(HTTPTransport):
 
-    scheme = ['twisted+http']
+    scheme = ['twisted+http', 'twisted+https']
 
     def __init__(self, parsed_url):
         if not has_twisted:


### PR DESCRIPTION
`twisted.web.client.getPage` handles HTTPS transparently, so `twisted+https` should also be a valid scheme. :)
