### PR TITLE
sanitize AMEX CC#s in SanitizePasswordsProcessor

### DIFF
--- a/raven/processors.py
+++ b/raven/processors.py
@@ -50,12 +50,12 @@ class RemoveStackLocalsProcessor(Processor):
 
 class SanitizePasswordsProcessor(Processor):
     """
-    Asterisk out passwords from password fields in frames, http,
-    and basic extra data.
+    Asterisk out things that look like passwords and credit
+    card numbers in frames, http, and basic extra data.
     """
     MASK = '*' * 8
     FIELDS = frozenset(['password', 'secret', 'passwd'])
-    VALUES_RE = re.compile(r'^\d{16}$')
+    VALUES_RE = re.compile(r'^\d{15,16}$')
 
     def sanitize(self, key, value):
         if value is None:

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -122,6 +122,12 @@ class SantizePasswordsProcessorTest(TestCase):
         result = proc.sanitize('foo', '4242424242424242')
         self.assertEquals(result, proc.MASK)
 
+    def test_sanitize_credit_card_amex(self):
+        # AMEX numbers are 15 digits, not 16
+        proc = SanitizePasswordsProcessor(Mock())
+        result = proc.sanitize('foo', '424242424242424')
+        self.assertEquals(result, proc.MASK)
+
 
 class RemovePostDataProcessorTest(TestCase):
     def test_does_remove_data(self):


### PR DESCRIPTION
AMEX numbers are 15 characters rather than 16.  This patches SanitizePasswordsProcessor to asterisk-out fields that look like AMEX numbers as well as "regular" 16-digit ones.

I also updated the docstring to better reflect what SanitizePasswordsProcessor actually does.
