### PR TITLE
[Flask] Handle disconnected clients when reading form data

### DIFF
--- a/raven/contrib/flask/utils.py
+++ b/raven/contrib/flask/utils.py
@@ -1,17 +1,23 @@
 import urlparse
 
 from raven.utils.wsgi import get_headers, get_environ
+from werkzeug.exceptions import ClientDisconnected
 
 
 def get_data_from_request(request):
     urlparts = urlparse.urlsplit(request.url)
+    
+    try: 
+        formdata = request.form
+    except ClientDisconnected:
+        formdata = {}
 
     return {
         'sentry.interfaces.Http': {
             'url': '%s://%s%s' % (urlparts.scheme, urlparts.netloc, urlparts.path),
             'query_string': urlparts.query,
             'method': request.method,
-            'data': request.form,
+            'data': formdata,
             'headers': dict(get_headers(request.environ)),
             'env': dict(get_environ(request.environ)),
         }


### PR DESCRIPTION
Fixes #184

Disconnects cant be reliably detected apparently, but based on some testing I dont believe we need to protect anything more than accessing form data.
