### PR TITLE
Be compatible with old versions of simplejson

### DIFF
--- a/raven/utils/json.py
+++ b/raven/utils/json.py
@@ -13,9 +13,12 @@ import uuid
 
 try:
     import simplejson as json
-    JSONDecodeError = json.JSONDecodeError
 except ImportError:
     import json
+
+try:
+    JSONDecodeError = json.JSONDecodeError
+except AttributeError:
     JSONDecodeError = ValueError
 
 


### PR DESCRIPTION
Older versions of simplejson don't have JSONDecodeError
