### PR TITLE
Django 1.5 compatibility

### DIFF
--- a/raven/contrib/django/serializers.py
+++ b/raven/contrib/django/serializers.py
@@ -22,7 +22,9 @@ class PromiseSerializer(Serializer):
             return False
 
         pre = value.__class__.__name__[1:]
-        if not (hasattr(value, '%s__func' % pre) or hasattr(value, '%s__unicode_cast' % pre)):
+        if not (hasattr(value, '%s__func' % pre) or \
+            hasattr(value, '%s__unicode_cast' % pre) or \
+            hasattr(value, '%s__text_cast' % pre)):
             return False
 
         return True


### PR DESCRIPTION
Due to the python3 for django 1.5 the __unicode_cast has been split into __text_cast and __bytes_cast.
I've added __text_cast although I'm not sure if it shouldn't have been __bytes_cast
