### PR TITLE
Added capability to explicitly define the server_name in a client.capture()

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -287,8 +287,13 @@ class Client(object):
 
         if not data.get('level'):
             data['level'] = kwargs.get('level') or logging.ERROR
-        data['modules'] = get_versions(self.include_paths)
-        data['server_name'] = self.name
+
+        if not data.get('server_name'):
+            data['server_name'] = self.name
+
+        if not data.get('modules'):
+            data['modules'] = get_versions(self.include_paths)
+
         data['tags'] = tags
         data.setdefault('extra', {})
         data.setdefault('level', logging.ERROR)


### PR DESCRIPTION
We needed a way to explicitly define the server_name in a raven capture event.

The Client.capture() method in raven/base.py allowed custom values for most of the attributes inside the data packet, but used a server_name that was populated when the Client instance was created and not on each capture() call. Our change simply allows server_name to be overridden on each capture event.
