### PR TITLE
A fix to tornado SentryMixin so that user can correctly pass custom data

### DIFF
--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -227,7 +227,12 @@ class SentryMixin(object):
         if data is None:
             data = self.get_default_context()
         else:
-            data = dict(self.get_default_context(), data)
+            default_context = self.get_default_context()
+            if isinstance(data, dict):
+                default_context.update(data)
+            else:
+                default_context['extra']['extra_data'] = data
+            data = default_context
 
         client = self.get_sentry_client()
 


### PR DESCRIPTION
Fix passing extra data to tornado's SentryMixin._capture will cause exception

dict(a, b) is not a correct way to merge two dict
