### PR TITLE
This adds the Django sites (domain) name to sentry.

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 import logging
 
 from django.conf import settings
+from django.contrib.sites import models as site_models
 from django.http import HttpRequest
 from django.template import TemplateSyntaxError
 from django.template.loader import LoaderOrigin
@@ -83,7 +84,9 @@ class DjangoClient(Client):
                     frame['in_app'] = False
 
         if 'django.contrib.sites' in settings.INSTALLED_APPS:
-            data['tags'].setdefault('site', settings.SITE_ID)
+            site = site_models.Site.objects.get_current()
+            site_name = site.name or site.domain
+            data['tags'].setdefault('site', site_name)
 
         return data
 

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -424,15 +424,14 @@ class DjangoClientTest(TestCase):
                 assert frame.get('in_app') is False
 
     def test_adds_site_to_tags(self):
-        with Settings(SITE_ID=1000, INSTALLED_APPS=list(settings.INSTALLED_APPS) + ['django.contrib.sites']):
-            self.assertRaises(TemplateSyntaxError, self.client.get, reverse('sentry-template-exc'))
+        self.assertRaises(TemplateSyntaxError, self.client.get, reverse('sentry-template-exc'))
 
         self.assertEquals(len(self.raven.events), 1)
         event = self.raven.events.pop(0)
 
         tags = event['tags']
         assert 'site' in event['tags']
-        assert tags['site'] == 1000
+        assert tags['site'] == u'example.com'
 
 
 class DjangoLoggingTest(TestCase):


### PR DESCRIPTION
If the site name is not defined the domain name is returned.
