### PR TITLE
Update raven/contrib/django/urls.py

### DIFF
--- a/raven/contrib/django/urls.py
+++ b/raven/contrib/django/urls.py
@@ -7,7 +7,11 @@ raven.contrib.django.urls
 """
 from __future__ import absolute_import
 
-from django.conf.urls.defaults import patterns, url
+try: 
+    from django.conf.urls import patterns, url
+except ImportError: 
+    # for Django version less then 1.4
+    from django.conf.urls.defaults import patterns, url
 
 urlpatterns = patterns('',
     url(r'^api/(?:(?P<project_id>[\w_-]+)/)?store/$', 'raven.contrib.django.views.report', name='raven-report'),


### PR DESCRIPTION
fix deprecated for Django 1.5
