### PR TITLE
Allow sending tags to the sentry server

### DIFF
--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -17,7 +17,7 @@ from raven.base import Client
 from raven.utils.encoding import to_string
 from raven.utils.stacks import iter_stack_frames
 
-RESERVED = ('stack', 'name', 'module', 'funcName', 'args', 'msg', 'levelno', 'exc_text', 'exc_info', 'data', 'created', 'levelname', 'msecs', 'relativeCreated')
+RESERVED = ('stack', 'name', 'module', 'funcName', 'args', 'msg', 'levelno', 'exc_text', 'exc_info', 'data', 'created', 'levelname', 'msecs', 'relativeCreated', 'tags')
 
 
 class SentryHandler(logging.Handler, object):
@@ -123,6 +123,8 @@ class SentryHandler(logging.Handler, object):
         date = datetime.datetime.utcfromtimestamp(record.created)
         event_type = 'raven.events.Message'
         handler_kwargs = {'message': record.msg, 'params': record.args}
+        if hasattr(record, 'tags'):
+          handler_kwargs['tags'] = record.tags
 
         # If there's no exception being processed, exc_info may be a 3-tuple of None
         # http://docs.python.org/library/sys.html#sys.exc_info


### PR DESCRIPTION
Sentry allows for sending tags with events. This is useful for later filtering of events. Raven should allow users to send tags.
