### PR TITLE
Fix django logging handler circular import bug

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import
 import logging
 
 from django.conf import settings
-from django.contrib.sites import models as site_models
 from django.http import HttpRequest
 from django.template import TemplateSyntaxError
 from django.template.loader import LoaderOrigin
@@ -84,6 +83,7 @@ class DjangoClient(Client):
                     frame['in_app'] = False
 
         if 'django.contrib.sites' in settings.INSTALLED_APPS:
+            from django.contrib.sites import models as site_models
             site = site_models.Site.objects.get_current()
             site_name = site.name or site.domain
             data['tags'].setdefault('site', site_name)


### PR DESCRIPTION
c5d2d16d907b91695608766993eb3ae277edc9bb introduces a circular import bug when adding the sentry handler to django logging in settings.py, as per the sentry docs. Django tries to configure logging, which imports the sentry handler, which imports the django client, which imports models from the django sites framework -  the circular import.

The bug causes this error:

```
Unable to configure handler 'sentry': 'module' object has no attribute 'django'
```

This patch simply defers the `django.contrib.sites` import until it is actually needed.
