### PR TITLE
When client is disabled, disable Sentry404CatchMiddleware

### DIFF
--- a/raven/contrib/django/middleware/__init__.py
+++ b/raven/contrib/django/middleware/__init__.py
@@ -16,7 +16,7 @@ import logging
 
 class Sentry404CatchMiddleware(object):
     def process_response(self, request, response):
-        if response.status_code != 404 or _is_ignorable_404(request.get_full_path()):
+        if response.status_code != 404 or _is_ignorable_404(request.get_full_path()) or not client.is_enabled():
             return response
         data = client.get_data_from_request(request)
         data.update({

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -69,6 +69,11 @@ class TempStoreClient(DjangoClient):
         return True
 
 
+class DisabledTempStoreClient(TempStoreClient):
+    def is_enabled(self, **kwargs):
+        return False
+
+
 class Settings(object):
     """
     Allows you to define settings that are required for this function to work.
@@ -341,6 +346,15 @@ class DjangoClientTest(TestCase):
             self.assertEquals(http['method'], 'GET')
             self.assertEquals(http['query_string'], '')
             self.assertEquals(http['data'], None)
+
+    def test_404_middleware_when_disabled(self):
+        extra_settings = {
+            'MIDDLEWARE_CLASSES': ['raven.contrib.django.middleware.Sentry404CatchMiddleware'],
+            'SENTRY_CLIENT': 'tests.contrib.django.tests.DisabledTempStoreClient',
+        }
+        with Settings(**extra_settings):
+            resp = self.client.get('/non-existant-page')
+            self.assertEquals(resp.status_code, 404)
 
     def test_response_error_id_middleware(self):
         # TODO: test with 500s


### PR DESCRIPTION
When disabling the Sentry client, the Sentry404CatchMiddleware still attempts to capture 404s.  This raises a TypeError.  This commit fixes that and adds tests.
