### PR TITLE
Fix when using Raven in Django with raven.contrib.django.raven_compat path

### DIFF
--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -199,6 +199,6 @@ def register_serializers():
     import raven.contrib.django.serializers  # NOQA
 
 if ('raven.contrib.django' in django_settings.INSTALLED_APPS
-      or 'raven.contrib.django_compat' in django_settings.INSTALLED_APPS):
+      or 'raven.contrib.django.raven_compat' in django_settings.INSTALLED_APPS):
     register_handlers()
     register_serializers()


### PR DESCRIPTION
It didn't register any exception handlers because it was looking for raven.contrib.django_compat.
