### PR TITLE
Logbook: Send log level as its string representation

### DIFF
--- a/raven/handlers/logbook.py
+++ b/raven/handlers/logbook.py
@@ -59,7 +59,7 @@ class SentryHandler(logbook.Handler):
 
     def _emit(self, record):
         data = {
-            'level': record.level,
+            'level': logbook.get_level_name(record.level).lower(),
             'logger': record.channel,
         }
 


### PR DESCRIPTION
Currently, if a log entry is recorded @ e.g. `error` level it won't be recorded as such unless an exception is passed along as well. The requested change is needed for sentry to handle the entry properly. Changing the log level that raven passes on to sentry from an integer to its string representation fixes this. I'm not that versed in sentry or raven yet so I can't say 100% that this is a proper solution. This fix did however work according to my needs (blue/yellow/red background circles etc.).

I don't know if this applies to `logging` as well, I've only had time to test it with `logbook`.
