### PR TITLE
Fix process_failure_signal to support Celery before 2.4

### DIFF
--- a/raven/contrib/celery/__init__.py
+++ b/raven/contrib/celery/__init__.py
@@ -38,8 +38,15 @@ class CeleryFilter(logging.Filter):
 def register_signal(client):
     def process_failure_signal(sender, task_id, exception, args, kwargs,
                                traceback, einfo, **kw):
+        if hasattr(einfo, 'exc_info'):
+            # for Celery 2.4 or later
+            exc_info = einfo.exc_info
+        else:
+            # for Celery before 2.4
+            exc_info = (type(exception), exception, traceback)
+
         client.captureException(
-            exc_info=einfo.exc_info,
+            exc_info=exc_info,
             extra={
                 'task_id': task_id,
                 'task': sender,


### PR DESCRIPTION
I'm trying to use raven with Celery 2.2. (It's old!)

The "ExceptionInfo" structure defined in Celery <= 2.3 didn't have 'exc_info':

https://github.com/celery/celery/blob/2.3-archived/celery/datastructures.py#L169

Previously, process_failure_signal was not depend on 'exc_info':

https://github.com/getsentry/raven-python/pull/122/files

The attached patch should support both structure.
(Tested with Celery 2.2.7)
