### PR TITLE
Update raven/utils/serializer/base.py

### DIFF
--- a/raven/utils/serializer/base.py
+++ b/raven/utils/serializer/base.py
@@ -95,7 +95,7 @@ class StringSerializer(Serializer):
 
     def serialize(self, value, **kwargs):
         string_max_length = kwargs.get('string_max_length', None)
-        return to_string(value)[:string_max_length]
+        return to_string(value).decode('utf8')[:string_max_length].encode('utf8')
 
 
 class TypeSerializer(Serializer):


### PR DESCRIPTION
This is hot fix for one problem with truncating utf8 encoded strings. 

If string in value is utf8 encoded raw string, then after truncating it may be truncated on the middle of unicode char. After that json.dumps will fail, for example:

``` python
import json
print json.dumps({1: '\xd1\x88\xd1\x82'})
{"1": "\u0448\u0442"}
json.dumps({1: '\xd1\x88\xd1\x82'[:3]})
UnicodeDecodeError
```

I know that this is not the best solution, because it add additional encode/decode operations. I believe that you will find more beautiful.

Thanks  

P.S. My environment: Python 2.6.6 (r266:84292), raven.VERSION '3.1.4'
