### PR TITLE
exc_info isn't supplied when tornado calls write_error

### DIFF
--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -248,5 +248,5 @@ class SentryMixin(object):
         """Override implementation to report all exceptions to sentry.
         """
         rv = super(SentryMixin, self).write_error(status_code, **kwargs)
-        self.captureException(exc_info=kwargs['exc_info'])
+        self.captureException(exc_info=kwargs.get('exc_info'))
         return rv


### PR DESCRIPTION
I got an exception like this:

```
2013-02-14 18:34:22 SAST+0000 - ERROR - root - send_error - Uncaught exception in write_error
Traceback (most recent call last):
  File "/home/stefanor/git/yola/formservice/virtualenv/local/lib/python2.7/site-packages/tornado-2.4-py2.7.egg/tornado/web.py", line 746, in send_error
    self.write_error(status_code, **kwargs)
  File "/home/stefanor/git/yola/formservice/virtualenv/local/lib/python2.7/site-packages/raven-3.1.0-py2.7.egg/raven/contrib/tornado/__init__.py", line 246, in write_error
    self.captureException(exc_info=kwargs['exc_info'])
KeyError: 'exc_info'
```

It looks like we should just default exc_info to None, like `captureExceptions` does.
