### PR TITLE
Small change to init_app() to allow passing the dns

### DIFF
--- a/raven/contrib/flask/__init__.py
+++ b/raven/contrib/flask/__init__.py
@@ -87,8 +87,12 @@ class Sentry(object):
             },
         )
 
-    def init_app(self, app):
+    def init_app(self, app, dsn=None):
         self.app = app
+
+        if dsn is not None:
+            self.dsn = dsn
+
         if not self.client:
             self.client = make_client(self.client_cls, app, self.dsn)
 


### PR DESCRIPTION
This is for cases where the config isn't available until the app is constructed. Otherwise, you have to do:

``` python
if app.config.get('SENTRY_DSN'):
        sentry.dsn = app.config.get('SENTRY_DSN')
        sentry.init_app(app)
```

Instead you should be able to do:

``` python
sentry.init_app(app, dsn=app.config.get('SENTRY_DSN'))
```
