### PR TITLE
Fix capturing Celery exceptions

### DIFF
--- a/raven/contrib/celery/__init__.py
+++ b/raven/contrib/celery/__init__.py
@@ -33,10 +33,7 @@ class CeleryClient(CeleryMixin, Client):
 class CeleryFilter(logging.Filter):
     def filter(self, record):
         # Context is fixed in Celery 3.x so use internal flag ignstead
-        keep_record = getattr(record, 'internal',
-            record.funcName != '_log_error')
-
-        return keep_record
+        return getattr(record, 'internal', record.funcName != '_log_error')
 
 
 def register_signal(client):


### PR DESCRIPTION
Celery fixes logging context in 3.x so have to use the 'internal' flag instead
Also, the failure signal is called within the stack so let raven do its magic to capture the frames
