### PR TITLE
Async suport on threaded transport

### DIFF
--- a/raven/transport/base.py
+++ b/raven/transport/base.py
@@ -251,7 +251,6 @@ class GeventedHTTPTransport(HTTPTransport):
 class TwistedHTTPTransport(AsyncTransport, HTTPTransport):
 
     scheme = ['twisted+http', 'twisted+https']
-    async = True
 
     def __init__(self, parsed_url):
         if not has_twisted:


### PR DESCRIPTION
This ensures that the threaded transport calls the new success/failure callbacks so that the client state is updated correctly
