### PR TITLE
avoid a ValueError

### DIFF
--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -85,6 +85,8 @@ def get_versions(module_list=None):
                 __import__(module_name)
             except ImportError:
                 continue
+	    except ValueError:
+		continue
 
             try:
                 app = sys.modules[module_name]


### PR DESCRIPTION
Sometimes I got tracebak like this :

Traceback (most recent call last):
  File "/home/cyp/buildout-eggs/waitress-0.8.2-py2.7.egg/waitress/channel.py", line 329, in service
    task.service()
  File "/home/cyp/buildout-eggs/waitress-0.8.2-py2.7.egg/waitress/task.py", line 173, in service
    self.execute()
  File "/home/cyp/buildout-eggs/waitress-0.8.2-py2.7.egg/waitress/task.py", line 396, in execute
    for chunk in app_iter:
  File "/home/cyp/buildout-eggs/raven-3.3.7-py2.7.egg/raven/middleware.py", line 32, in **call**
    self.handle_exception(environ)
  File "/home/cyp/buildout-eggs/raven-3.3.7-py2.7.egg/raven/middleware.py", line 60, in handle_exception
    'env': dict(get_environ(environ)),
  File "/home/cyp/buildout-eggs/raven-3.3.7-py2.7.egg/raven/base.py", line 594, in captureException
    'raven.events.Exception', exc_info=exc_info, *_kwargs)
  File "/home/cyp/buildout-eggs/raven-3.3.7-py2.7.egg/raven/base.py", line 459, in capture
    *_kwargs)
  File "/home/cyp/buildout-eggs/raven-3.3.7-py2.7.egg/raven/base.py", line 336, in build_msg
    data['modules'] = self.get_module_versions()
  File "/home/cyp/buildout-eggs/raven-3.3.7-py2.7.egg/raven/base.py", line 216, in get_module_versions
    return get_versions(self.include_paths)
  File "/home/cyp/buildout-eggs/raven-3.3.7-py2.7.egg/raven/utils/**init**.py", line 85, in get_versions
    **import**(module_name)
ValueError: Empty module name

The patch is for avoid this kind of traceback.
