### PR TITLE
Respect log level overriding from kwargs in Exception handler

### DIFF
--- a/raven/events.py
+++ b/raven/events.py
@@ -67,7 +67,7 @@ class Exception(BaseEvent):
             exc_type = getattr(exc_type, '__name__', '<unknown>')
 
             return {
-                'level': logging.ERROR,
+                'level': kwargs.get('level', logging.ERROR),
                 'sentry.interfaces.Exception': {
                     'value': to_unicode(exc_value),
                     'type': str(exc_type),


### PR DESCRIPTION
Currently the `raven.events.Exception` handler hardcodes the logging level to `logging.ERROR`. We have a use case wherein we expect certain errors to come up, but would like to log them to Sentry at a lower level, because they are expected. This actually happens if `level` is specified in kwargs for `Client.capture`, but is not propagated down to the handler. This is the easiest solution, but we could also specify another handler for warning exceptions.
