### PR TITLE
Avoid creating circular reference cycles by sidestepping the use of a local variable to sys.exc_info[2]

### DIFF
--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -149,16 +149,16 @@ def get_client(client=None):
 
 
 def sentry_exception_handler(request=None, **kwargs):
-    exc_info = sys.exc_info()
+    exc_type = sys.exc_info()[0]
 
-    if exc_info[0].__name__ in get_option('IGNORE_EXCEPTIONS', ()):
+    if exc_type.__name__ in get_option('IGNORE_EXCEPTIONS', ()):
         logger.info(
-            'Not capturing exception due to filters: %s', exc_info[0],
-            exc_info=exc_info)
+            'Not capturing exception due to filters: %s', exc_type,
+            exc_info=sys.exc_info())
         return
 
     try:
-        client.captureException(exc_info=exc_info, request=request)
+        client.captureException(exc_info=sys.exc_info(), request=request)
     except Exception as exc:
         try:
             logger.exception('Unable to process log entry: %s' % (exc,))


### PR DESCRIPTION
This avoids the need to rely on the Python garbage collector to detect and remove unreachable cycles.

See: https://code.djangoproject.com/ticket/10758#no1 and http://pymotw.com/2/sys/exceptions.html

Also see: https://code.djangoproject.com/attachment/ticket/10758/patch.diff
