### PR TITLE
Added 'authorization' to sanitize

### DIFF
--- a/raven/processors.py
+++ b/raven/processors.py
@@ -56,7 +56,7 @@ class SanitizePasswordsProcessor(Processor):
     card numbers in frames, http, and basic extra data.
     """
     MASK = '*' * 8
-    FIELDS = frozenset(['password', 'secret', 'passwd'])
+    FIELDS = frozenset(['password', 'secret', 'passwd', 'authorization'])
     VALUES_RE = re.compile(r'^(?:\d[ -]*?){13,16}$')
 
     def sanitize(self, key, value):


### PR DESCRIPTION
This will keep Basic Authorization password headers from showing up base64
encoded inside the Sentry admin.
