### PR TITLE
Convert kwargs to strings in order to support python 2.6

### DIFF
--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -141,7 +141,11 @@ def get_client(client=None):
 
         class_name = str(class_name)
 
-        instance = getattr(__import__(module, {}, {}, class_name), class_name)(**options)
+        try:
+            instance = getattr(__import__(module, {}, {}, class_name), class_name)(**options)
+        except TypeError:
+            # Python 2.6 compatibility fix
+            instance = getattr(__import__(module, {}, {}, class_name), class_name)(**dict([(str(key), val) for key, val in options.items()]))
         if not tmp_client:
             _client = (client, instance)
         return instance


### PR DESCRIPTION
Python 2.6 does not allow unicode keys for kwarg dicts and raises a TypeError
