### PR TITLE
Adds support for tagging logs emited via python logging module

### DIFF
--- a/raven/contrib/django/handlers.py
+++ b/raven/contrib/django/handlers.py
@@ -25,5 +25,7 @@ class SentryHandler(BaseSentryHandler):
 
     def _emit(self, record):
         request = getattr(record, 'request', None)
-
-        return super(SentryHandler, self)._emit(record, request=request)
+        
+        tags = dict() if not 'tags' in record.__dict__ else record.__dict__['tags']
+        
+        return super(SentryHandler, self)._emit(record, request=request, tags=tags)


### PR DESCRIPTION
I didn't find any straightforward way to tag logs within sentry context using traditional python logging module. This pull request adds support for tagging logs using python logging module. I think this functionality can be added within raven core and not just to `raven.contrib.django.handlers`. I will be happy to modify this PR if required.

```
>>> import logging
>>> logger = logging.getLogger(__name__)
>>> logger.debug("log message that will be tagged within sentry context", extra={"tags":{"key1":"val1", "key2":"val2"}})
```
