### PR TITLE
tornado: Split AsyncSentryClient in sync/async

### DIFF
--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -105,7 +105,10 @@ class SentryClient(Client):
 
 try:
     from tornado.httpclient import AsyncHTTPClient, HTTPError
+except ImportError:
+    AsyncHTTPClient, HTTPError = None, None
 
+if AsyncHTTPClient:
     class AsyncSentryClient(SentryClient):
 
         HTTP_ERROR = HTTPError
@@ -122,9 +125,6 @@ try:
             return AsyncHTTPClient().fetch(
                 url, callback, method="POST", body=data, headers=headers
             )
-
-except ImportError as e:
-    pass
 
 
 class SentryMixin(object):


### PR DESCRIPTION
Motivation is as follows:

Tornado is partially supported on Google App Engine (https://github.com/facebook/tornado/tree/master/demos/appengine). GAE's sandbox won't allow tornado's async support, so importing tornado.ioloop results in this error:

```
File "/home/vagrant/workspace/myproject/lib/python2.7/site-packages/tornado/platform/posix.py", line 21, in <module>
    import fcntl
File "/opt/google_appengine/google/appengine/tools/devappserver2/python/sandbox.py", line 822, in load_module
    raise ImportError('No module named %s' % fullname)
ImportError: No module named fcntl
```

Thus, without this patch, the contrib.tornado module can't be imported in such environments. For other environments nothing changes and this should be backwards compatible. Applications running tornado on GAE can import this module and subclass contrib.tornado.SentryClient and implement the http client part using the urlfetch service ( https://developers.google.com/appengine/docs/python/urlfetch/).
