### PR TITLE
Handle recursion errors

### DIFF
--- a/raven/contrib/zope/__init__.py
+++ b/raven/contrib/zope/__init__.py
@@ -55,7 +55,10 @@ class ZopeSentryHandler(SentryHandler):
                     request = frame.f_locals.get('request', None)
                     if not request:
                         view = frame.f_locals.get('self', None)
-                        request = getattr(view, 'request', None)
+                        try:
+                            request = getattr(view, 'request', None)
+                        except RuntimeError:
+                            request = None
                 if not exc_info:
                     exc_info = frame.f_locals.get('exc_info', None)
                     if not hasattr(exc_info, '__getitem__'):


### PR DESCRIPTION
In some cases, for example when a frame is App.ZApplication.ZApplicationWrapper, then "frame.f_locals.get('self', None)" raises a maximum recursion depth error. This fix catches these and moves further so Zope continues to run (without the fix Zope breaks) and we still get a (request-less) error report in Sentry.
