### PR TITLE
fixed indent bug

### DIFF
--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -194,16 +194,16 @@ def register_handlers():
                 register_signal, register_logger_signal)
         except ImportError:
             logger.exception('Failed to install Celery error handler')
-        else:
-            try:
-                register_signal(client)
-            except Exception:
-                logger.exception('Failed to install Celery error handler')
+    else:
+        try:
+            register_signal(client)
+        except Exception:
+            logger.exception('Failed to install Celery error handler')
 
-            try:
-                register_logger_signal(client)
-            except Exception:
-                logger.exception('Failed to install Celery error handler')
+        try:
+            register_logger_signal(client)
+        except Exception:
+            logger.exception('Failed to install Celery error handler')
 
 
 def register_serializers():


### PR DESCRIPTION
When using celeryd and raven.contrib.django.celery.CeleryClient together, there is an import bug when starting the celery worker.

There is an indent bug in the code which seems to resolve the issue.
