### PR TITLE
Hide Django sensitive datas

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -107,6 +107,9 @@ class DjangoClient(Client):
                 'cookies': dict(request.COOKIES),
                 'headers': dict(get_headers(environ)),
                 'env': dict(get_environ(environ)),
+                'sensitive_post_params':
+                    request.sensitive_post_parameters and
+                    request.sensitive_post_parameters or False
             }
         })
 


### PR DESCRIPTION
If use "sensitive_post_parameters" decorator in Django, running perfectly but raven send to sentry everything. Request Body have all datas (sensitive too). I fixed this for replace <hidden>.
