### PR TITLE
don't send logs from send_error when status_code is 400 ~ 499

### DIFF
--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -260,5 +260,6 @@ class SentryMixin(object):
             return super(SentryMixin, self).send_error(status_code, **kwargs)
         else:
             rv = super(SentryMixin, self).send_error(status_code, **kwargs)
-            self.captureException(exc_info=kwargs.get('exc_info'))
+            if 500 =< status_code <= 599:
+                self.captureException(exc_info=kwargs.get('exc_info'))
             return rv


### PR DESCRIPTION
Hey, I don't think when using self.send_error response 4XX status is a good idea.I catch up a lot of None Type event in sentry.
