### PR TITLE
use stacktrace field of Exception interface

### DIFF
--- a/raven/events.py
+++ b/raven/events.py
@@ -73,9 +73,9 @@ class Exception(BaseEvent):
                     'value': to_unicode(exc_value),
                     'type': str(exc_type),
                     'module': to_unicode(exc_module),
-                },
-                'sentry.interfaces.Stacktrace': {
-                    'frames': frames
+                    'stacktrace': {
+                        'frames': frames
+                    }
                 },
             }
         finally:


### PR DESCRIPTION
Leave `sentry.interfaces.Stacktrace` for non-exception information, e.g.
a client may want to record both exception traceback and the call stack.
