### PR TITLE
Django client's get_data_from_request method did not correctly assign request.POST 

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -77,10 +77,10 @@ class DjangoClient(Client):
                 data = request.body
             except:
                 try:
-                    data = request.raw_post_data and request.raw_post_data or request.POST
+                    data = request.raw_post_data
                 except Exception:
                     # assume we had a partial read:
-                    data = '<unavailable>'
+                    data = request.POST or '<unavailable>'
         else:
             data = None
 

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -19,6 +19,7 @@ from django.core.exceptions import SuspiciousOperation
 from django.core.urlresolvers import reverse
 from django.core.signals import got_request_exception
 from django.core.handlers.wsgi import WSGIRequest
+from django.http.request import QueryDict
 from django.template import TemplateSyntaxError
 from django.test import TestCase
 
@@ -428,6 +429,21 @@ class DjangoClientTest(TestCase):
         http = event['sentry.interfaces.Http']
         self.assertEquals(http['method'], 'POST')
         self.assertEquals(http['data'], '<unavailable>')
+
+    def test_read_post_data(self):
+        request = make_request()
+        request.POST = QueryDict("foo=bar&ham=spam")
+        request.read(1)
+
+        self.raven.captureMessage(message='foo', request=request)
+
+        self.assertEquals(len(self.raven.events), 1)
+        event = self.raven.events.pop(0)
+
+        self.assertTrue('sentry.interfaces.Http' in event)
+        http = event['sentry.interfaces.Http']
+        self.assertEquals(http['method'], 'POST')
+        self.assertEquals(http['data'], {u'foo': u'bar', u'ham': u'spam'})
 
     # This test only applies to Django 1.3+
     def test_request_capture(self):


### PR DESCRIPTION
This PR is to fix Raven's django client assigning string `<unavailable>` on `result['sentry.interfaces.Http']['data']` on method `get_data_from_request`, even when we have correct POST variables in the request.

Also in this PR, I added test case for this issue
# Before:

![selection_143](https://f.cloud.github.com/assets/1240672/1113109/b9588832-19f3-11e3-8d3a-4d8627000344.png)
# Result after this change:

![selection_142](https://f.cloud.github.com/assets/1240672/1113117/dd7eda86-19f3-11e3-9e67-eec3bfbf44e0.png)
