### PR TITLE
Avoid TypeError when serializing 'bytes' in Python 3

### DIFF
--- a/raven/utils/json.py
+++ b/raven/utils/json.py
@@ -30,6 +30,8 @@ class BetterJSONEncoder(json.JSONEncoder):
             return obj.strftime('%Y-%m-%dT%H:%M:%SZ')
         elif isinstance(obj, (set, frozenset)):
             return list(obj)
+        elif isinstance(obj, bytes):
+            return obj.decode('utf-8', errors='replace')
         return super(BetterJSONEncoder, self).default(obj)
 
 


### PR DESCRIPTION
I am using custom middleware in Django 1.5 (running on Python 3.3) with custom `process_exception` where the raven is called explicitly using `sentry_exception_handler(request=request)`.

Raven fails when trying to serialize Django request body.

``` py3tb
Traceback (most recent call last):
  File "(hidden)/venv/lib/python3.3/site-packages/raven/contrib/django/models.py", line 161, in sentry_exception_handler
    client.captureException(exc_info=sys.exc_info(), request=request)
  File "(hidden)/venv/lib/python3.3/site-packages/raven/base.py", line 595, in captureException
    'raven.events.Exception', exc_info=exc_info, **kwargs)
  File "(hidden)/venv/lib/python3.3/site-packages/raven/contrib/django/client.py", line 151, in capture
    result = super(DjangoClient, self).capture(event_type, **kwargs)
  File "(hidden)/venv/lib/python3.3/site-packages/raven/base.py", line 461, in capture
    self.send(**data)
  File "(hidden)/venv/lib/python3.3/site-packages/raven/contrib/django/client.py", line 171, in send
    return super(DjangoClient, self).send(**kwargs)
  File "(hidden)/venv/lib/python3.3/site-packages/raven/base.py", line 529, in send
    message = self.encode(data)
  File "(hidden)/venv/lib/python3.3/site-packages/raven/base.py", line 564, in encode
    return base64.b64encode(zlib.compress(json.dumps(data).encode('utf8')))
  File "(hidden)/venv/lib/python3.3/site-packages/raven/utils/json.py", line 41, in dumps
    return json.dumps(value, cls=BetterJSONEncoder, **kwargs)
  File "/usr/lib/python3.3/json/__init__.py", line 243, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.3/json/encoder.py", line 191, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.3/json/encoder.py", line 249, in iterencode
    return _iterencode(o, 0)
  File "(hidden)/venv/lib/python3.3/site-packages/raven/utils/json.py", line 33, in default
    return super(BetterJSONEncoder, self).default(obj)
  File "/usr/lib/python3.3/json/encoder.py", line 173, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: b'test=teststring' is not JSON serializable
```
