### PR TITLE
Don't ignore records for all modules starting with "raven"

### DIFF
--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -47,9 +47,10 @@ class SentryHandler(logging.Handler, object):
         logging.Handler.__init__(self, level=kwargs.get('level', logging.NOTSET))
 
     def can_record(self, record):
-        if record.name.startswith(('sentry.errors', 'raven')):
-            return False
-        return True
+        return not (
+            record.name == 'raven' or
+            record.name.startswith(('sentry.errors', 'raven.'))
+        )
 
     def emit(self, record):
         try:


### PR DESCRIPTION
Currently raven's logging handler ignores any errors coming from modules beginning with "raven", even though the module may not actually belong to raven and may be called something like "raven_utils". This change alters the logic to check for either an exact match on "raven", or a path starting with "raven." (including the namespace separator). This should cover both cases and allow for logging of errors from "raven_utils" but not from any module belonging to raven itself.
