### PR TITLE
fixed management BaseCommand patching, ...

### DIFF
--- a/raven/contrib/django/management/__init__.py
+++ b/raven/contrib/django/management/__init__.py
@@ -46,7 +46,7 @@ def patch_base_command(cls):
             raise
 
     new_execute.__raven_patched = True
-    BaseCommand.execute = new_execute
+    cls.execute = new_execute
 
     return True
 


### PR DESCRIPTION
...using the cls argument of patch_base_command, not the _optionally_ imported BaseCommand

Hi,

It was impossible to manually patch_base_comand(BaseCommand). We found that the cls argument was ignored line 49 when actually patching execute.

Regards.
