### PR TITLE
Fixes the BaseUDPTransport to use IPv4 by default

### DIFF
--- a/raven/transport/base.py
+++ b/raven/transport/base.py
@@ -133,7 +133,7 @@ class BaseUDPTransport(Transport):
             if v6_addresses and not v4_addresses:
                 # The only time we return a v6 address is if it's the only option
                 return v6_addresses[0]
-        return addresses[0]
+        return v4_addresses[0]
 
     def send(self, data, headers):
         auth_header = headers.get('X-Sentry-Auth')


### PR DESCRIPTION
This is a matching patch for getsentry/sentry#1073

getaddrinfo() does not make any guarantees about the ordering of IPv4 vs IPv6 addresses and BaseUDPTransport was just picking the first address from getaddrinfo.  This patch will fall back to using the first IPv4 address by default as per the documentation.  
