### PR TITLE
Make the threaded transport the default

### DIFF
--- a/raven/transport/base.py
+++ b/raven/transport/base.py
@@ -200,7 +200,7 @@ class UDPTransport(BaseUDPTransport):
 
 class HTTPTransport(Transport):
 
-    scheme = ['http', 'https']
+    scheme = ['sync+http', 'sync+https']
 
     def __init__(self, parsed_url, timeout=defaults.TIMEOUT):
         self.check_scheme(parsed_url)

--- a/raven/transport/threaded.py
+++ b/raven/transport/threaded.py
@@ -91,7 +91,7 @@ class AsyncWorker(object):
 
 class ThreadedHTTPTransport(AsyncTransport, HTTPTransport):
 
-    scheme = ['threaded+http', 'threaded+https']
+    scheme = ['http', 'https']
 
     def __init__(self, parsed_url):
         super(ThreadedHTTPTransport, self).__init__(parsed_url)
@@ -113,5 +113,5 @@ class ThreadedHTTPTransport(AsyncTransport, HTTPTransport):
             success_cb()
 
     def async_send(self, data, headers, success_cb, failure_cb):
-        self.get_worker().queue(self.send_sync, data, headers, success_cb,
-            failure_cb)
+        self.get_worker().queue(
+            self.send_sync, data, headers, success_cb, failure_cb)


### PR DESCRIPTION
sync+http would now be used for the single threaded (no worker) implementation
