### PR TITLE
Add Context.__len__() method

### DIFF
--- a/raven/context.py
+++ b/raven/context.py
@@ -34,6 +34,9 @@ class Context(local, Mapping, Iterable):
     def __iter__(self):
         return iter(self.data)
 
+    def __len__(self):
+        return len(self.data)
+
     def __repr__(self):
         return '<%s: %s>' % (type(self).__name__, self.data)
 


### PR DESCRIPTION
`Mapping.__len__()` is abstract and `Context` wasn't implementing it.  Normally, `Mapping`'s metaclass would therefore prevent `Context` from being instantiated, but this check is not performed due to `Context`'s multiple inheritance:

```
>>> from raven.context import Context
>>> Context()
<Context: {}>
```

However, when gunicorn is used with gevent workers, gevent supplies its own implementation of `threading.local` which does run the checks:

```
>>> import gevent.monkey
>>> gevent.monkey.patch_all()
>>> from raven.context import Context
>>> Context()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "[...]/gevent/local.py", line 141, in __new__
    self = object.__new__(cls)
TypeError: Can't instantiate abstract class Context with abstract methods __len__
```

Fix by implementing the method.
