### PR TITLE
init v4_address earlier

### DIFF
--- a/raven/transport/udp.py
+++ b/raven/transport/udp.py
@@ -31,9 +31,9 @@ class BaseUDPTransport(Transport):
         a v6 address if it's the only option.
         """
         addresses = getaddrinfo(host, port)
+        v4_addresses = [info for info in addresses if info[0] == AF_INET]
         if has_ipv6:
             v6_addresses = [info for info in addresses if info[0] == AF_INET6]
-            v4_addresses = [info for info in addresses if info[0] == AF_INET]
             if v6_addresses and not v4_addresses:
                 # The only time we return a v6 address is if it's the only option
                 return v6_addresses[0]


### PR DESCRIPTION
fix this problem:

> Traceback (most recent call last):
> File "/var/daes/lib/python2.7/site-packages/raven/base.py", line 549, in send_remote
>    transport.send(data, headers)
>  File "/var/daes/lib/python2.7/site-packages/raven/transport/udp.py", line 50, in send
>    addr_info = self._get_addr_info(host, int(port))
>  File "/var/daes/lib/python2.7/site-packages/raven/transport/udp.py", line 40, in _get_addr_info
>    return v4_addresses[0]
> UnboundLocalError: local variable 'v4_addresses' referenced before assignment
