### PR TITLE
Add option to disable SSL verification in Tornado

### DIFF
--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -20,6 +20,9 @@ class AsyncSentryClient(Client):
     asynchronously send errors to sentry. The client also captures the
     information from the request handlers
     """
+    def __init__(self, *args, **kwargs):
+        self.validate_cert = True
+        Client.__init__(self, *args, **kwargs)
     def capture(self, *args, **kwargs):
         """
         Takes the same arguments as the super function in :py:class:`Client`
@@ -102,7 +105,7 @@ class AsyncSentryClient(Client):
             self.state.set_fail()
         else:
             self.state.set_success()
-
+        
     def _send_remote(self, url, data, headers=None, callback=None):
         """
         Initialise a Tornado AsyncClient and send the reuqest to the sentry
@@ -113,7 +116,8 @@ class AsyncSentryClient(Client):
             headers = {}
 
         return AsyncHTTPClient().fetch(
-            url, callback, method="POST", body=data, headers=headers
+            url, callback, method="POST", body=data, headers=headers,
+            validate_cert = self.validate_cert
         )
 
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-python/issues/402

Currently it's not possible to pass the _validate_cert_ option to the sentry reporter. When using raven with a non-validatable server via HTTPS transport, the reporting doesn't work and a warning message is printed (see https://github.com/getsentry/raven-python/issues/402). 

This pull request allows a statement like this:

``` py
sentry_client = AsyncSentryClient(
            'https://foo:bar@foobarcom/2'
)
#That's new!.
self.sentry_client.validate_cert = False
```

The option is passed on to _AsyncHTTPClient.fetch()_.

By default, _validate_cert_ is True (therefore the default behaviour is not modified by this patch).

Merging would be highly appreciated!
