### PR TITLE
SENTRY_IGNORE_EXCEPTIONS now support wildcard '*' in Django

### DIFF
--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -154,7 +154,7 @@ def sentry_exception_handler(request=None, **kwargs):
     exclusions = set(get_option('IGNORE_EXCEPTIONS', ()))
 
     exc_name = '%s.%s' % (exc_type.__module__, exc_type.__name__)
-    if exc_type.__name__ in exclusions or exc_name in exclusions or any(exc_name.startswith(e[:-1]) for e in exclusions if e.endswith('*')):
+    if exc_type.__name__ in exclusions or exc_name in exclusions or any(exc_name.startswith(e[:-1]) for e in exclusions if e.endswith('*')) or any(e == '*' for e in exclusions):
         logger.info(
             'Not capturing exception due to filters: %s', exc_type,
             exc_info=sys.exc_info())


### PR DESCRIPTION
I was trying to use `django.request` logger to send uncaught Exception to Sentry via Raven. The problem is that I always get duplicated record logged by the `root` logger (presented on Sentry UI). After spending a few hours, I figured out that the `root` logger entry was created by `sentry_exception_handler`.

This PR add support to ignore all exceptions by specifying the following config in `settings.py`.

```
SENTRY_IGNORE_EXCEPTIONS = ('*', )
```
