### PR TITLE
Add body size limitation for tornado mixin class

### DIFF
--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -163,6 +163,8 @@ class SentryMixin(object):
     :py:class:`AsyncSentryClient`. This can be changed by implementing your
     own get_sentry_client method on your request handler.
     """
+    SENTRY_REQUEST_BODY_LIMIT = 1024 * 20
+    SENTRY_REQUEST_BODY_TRUNCATE = 200
 
     def get_sentry_client(self):
         """
@@ -179,11 +181,22 @@ class SentryMixin(object):
 
         :param return: A dictionary.
         """
+        if self.request.files:
+            body_length = len(self.request.body)
+            body = '<body with file(s), size:%s>' % body_length
+        elif body_length > self.SENTRY_REQUEST_BODY_LIMIT:
+            body_length = len(self.request.body)
+            truncate = self.SENTRY_REQUEST_BODY_TRUNCATE
+            body = '<large body, size:%s, first %s bytes: %s>' %\
+                   (body_length, truncate, self.request.body[:truncate])
+        else:
+            body = self.request.body
+
         return {
             'sentry.interfaces.Http': {
                 'url': self.request.full_url(),
                 'method': self.request.method,
-                'data': self.request.body,
+                'data': body,
                 'query_string': self.request.query,
                 'cookies': self.request.headers.get('Cookie', None),
                 'headers': dict(self.request.headers),


### PR DESCRIPTION
Recently I am working on a project that use tornado to handle file uploading, raven failed to send the report for exceptions happened during the uploading process, the traceback shows that when raven trying to encode the collected data:

``` python
# base.py line 570
        return base64.b64encode(zlib.compress(json.dumps(data).encode('utf8')))
```

encode utf8 failed and raised a `UnicodeEncodeError`.

I think it would be better if we set a limitation for the body size when getting request data, or just don't get the body if there's file in request, to avoid encoding problems caused by binary data.
