### PR TITLE
Support app.version as a way of getting the version

### DIFF
--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -78,7 +78,7 @@ def get_version_from_app(module_name, app):
         return None
 
     if isinstance(version, (list, tuple)):
-        version = '.'.join(str(o) for o in version)
+        version = '.'.join(map(str, version))
 
     return str(version)
 


### PR DESCRIPTION
Specifically, markdown does this. `__version__` is actually a module.
