### PR TITLE
SanitizePasswordsProcessor removes API keys

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -220,8 +220,9 @@ Several processors are included with Raven to assist in data sanitiziation. Thes
 
 .. data:: raven.processors.SanitizePasswordsProcessor
 
-   Removes all keys which resemble ``password`` or ``secret`` within stacktrace contexts, and HTTP
-   bits (such as cookies, POST data, the querystring, and environment).
+   Removes all keys which resemble ``password``, ``secret``, or ``api_key``
+   within stacktrace contexts and HTTP bits (such as cookies, POST data,
+   the querystring, and environment).
 
 .. data:: raven.processors.RemoveStackLocalsProcessor
 

--- a/raven/processors.py
+++ b/raven/processors.py
@@ -63,11 +63,13 @@ class RemoveStackLocalsProcessor(Processor):
 
 class SanitizePasswordsProcessor(Processor):
     """
-    Asterisk out things that look like passwords and credit
-    card numbers in frames, http, and basic extra data.
+    Asterisk out things that look like passwords, credit card numbers,
+    and API keys in frames, http, and basic extra data.
     """
     MASK = '*' * 8
-    FIELDS = frozenset(['password', 'secret', 'passwd', 'authorization'])
+    FIELDS = frozenset([
+        'password', 'secret', 'passwd', 'authorization', 'api_key', 'apikey'
+    ])
     VALUES_RE = re.compile(r'^(?:\d[ -]*?){13,16}$')
 
     def sanitize(self, key, value):


### PR DESCRIPTION
Minor change to `SanitizePasswordsProcessor` in order to sanitize keys matching `api_key` or `apikey`.

I've refactored tests to reuse a `VARS` module-level variable and deduplicate some assertions with a `_check_vars_sanitized` helper method.
