### PR TITLE
Fix Issue #430. 

### DIFF
--- a/raven/utils/stacks.py
+++ b/raven/utils/stacks.py
@@ -233,7 +233,7 @@ def get_stack_info(frames, transformer=transform, capture_locals=True,
         # This changes /foo/site-packages/baz/bar.py into baz/bar.py
         try:
             base_filename = sys.modules[module_name.split('.', 1)[0]].__file__
-            filename = abs_path.split(base_filename.rsplit('/', 2)[0], 1)[-1][1:]
+            filename = abs_path.split(base_filename.rsplit('/', 2)[0], 1)[-1].lstrip("/")
         except:
             filename = abs_path
 


### PR DESCRIPTION
Use lstrip to get rid of leading slashes, because in some cases the paths have already been replaced.
