### PR TITLE
DjangoClient: use fallback in case of ImportError of client

### DIFF
--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -141,10 +141,18 @@ def get_client(client=None):
 
         class_name = str(class_name)
 
-        instance = getattr(__import__(module, {}, {}, class_name), class_name)(**options)
-        if not tmp_client:
-            _client = (client, instance)
-        return instance
+        try:
+            instance = getattr(__import__(module, {}, {}, class_name), class_name)(**options)
+        except ImportError:
+            logger.exception('Failed to import client: %s', client)
+            if not _client[1]:
+                # If there is no previous client, set the default one.
+                client = 'raven.contrib.django.DjangoClient'
+                _client = (client, get_client(client))
+        else:
+            if not tmp_client:
+                _client = (client, instance)
+            return instance
     return _client[1]
 
 

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -385,6 +385,19 @@ class DjangoClientTest(TestCase):
             assert resp.status_code == 404
             assert self.raven.events == []
 
+    def test_invalid_client(self):
+        extra_settings = {
+            'SENTRY_CLIENT': 'raven.contrib.django.DjangoClient',  # default
+        }
+        # Should return fallback client (TempStoreClient)
+        client = get_client('nonexistant.and.invalid')
+
+        # client should be valid, and the same as with the next call.
+        assert client is get_client()
+
+        with Settings(**extra_settings):
+            assert isinstance(get_client(), DjangoClient)
+
     def test_response_error_id_middleware(self):
         # TODO: test with 500s
         with Settings(MIDDLEWARE_CLASSES=['raven.contrib.django.middleware.SentryResponseErrorIdMiddleware',


### PR DESCRIPTION
This fixes `AttributeError: 'NoneType' object has no attribute 'split'`
from the WSGI stack, because Sentry itself does not handle internal
exceptions properly.

This makes sure that the DjangoClient is valid, falling back to the
previously used one (in case a temporary client is given/requested), or
to the default client (typically ignoring the wrong user setting).

The ImportError gets logged (with an exception).

I would rather like to not catch the ImportError here, but make Sentry
handle it. On the other hand, it's the responsibility of DjangoClient to
provide a valid client object.

Fixes #433 (https://github.com/getsentry/raven-python/issues/433).
