### PR TITLE
Do not reset `test_args`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ tests_require = [
 class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_args = []
         self.test_suite = True
 
     def run_tests(self):


### PR DESCRIPTION
Resetting/emptying it prevents you from passing in any arguments to
pytest, e.g. for only running tests from a particular directory.
