### PR TITLE
Fix client.capture to use message from kwargs

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -357,7 +357,7 @@ class Client(object):
             data.update(processor.process(data))
 
         if 'message' not in data:
-            data['message'] = handler.to_string(data)
+            data['message'] = kwargs.get('message', handler.to_string(data))
 
         # tags should only be key=>u'value'
         for key, value in six.iteritems(data['tags']):

--- a/tests/base/tests.py
+++ b/tests/base/tests.py
@@ -224,6 +224,16 @@ class ClientTest(TestCase):
         event = self.client.events.pop(0)
         self.assertEquals(event['message'], 'foo')
 
+    def test_message_from_kwargs(self):
+        try:
+            raise ValueError('foo')
+        except:
+            self.client.captureException(message='test', data={})
+
+        self.assertEquals(len(self.client.events), 1)
+        event = self.client.events.pop(0)
+        self.assertEquals(event['message'], 'test')
+
     def test_explicit_message_on_exception_event(self):
         try:
             raise ValueError('foo')


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry/issues/1153
