### PR TITLE
Removed unused assignment

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -272,7 +272,6 @@ class Client(object):
 
         data.setdefault('tags', {})
         data.setdefault('extra', {})
-        data.setdefault('level', logging.ERROR)
 
         if stack is None:
             stack = self.auto_log_stacks


### PR DESCRIPTION
'level' field can be set in 337 line from function argument, but this assignment prevent it.
