### PR TITLE
Fix module version detection

### DIFF
--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -62,12 +62,12 @@ def get_version_from_app(module_name, app):
             version = get_version()
         else:
             version = get_version
+    elif hasattr(app, '__version__'):
+        version = app.__version__
     elif hasattr(app, 'VERSION'):
         version = app.VERSION
     elif hasattr(app, 'version'):
         version = app.version
-    elif hasattr(app, '__version__'):
-        version = app.__version__
     elif pkg_resources:
         # pull version from pkg_resources if distro exists
         try:


### PR DESCRIPTION
- Current implementation of get_version_from_app fails to get version
  information from modules such as `numpy`, `webassets` and `setuptools` since
  they define version information in the variable `<package>.__version__`
  and also include a module `<package>.version`. In the current
  implementation <package>.version takes precedence over
  `<package>.__version__` thus the version information reported is a module
  instead of version number. This is easily fixed by this commit which
  changes precedence (see also PEP396).
