### PR TITLE
Add trailing comma to args tuple in Pylons documentation

### DIFF
--- a/docs/config/pylons.rst
+++ b/docs/config/pylons.rst
@@ -56,7 +56,7 @@ Add the following lines to your project's `.ini` file to setup `SentryHandler`:
 
     [handler_sentry]
     class = raven.handlers.logging.SentryHandler
-    args = ('SENTRY_DSN')
+    args = ('SENTRY_DSN',)
     level = NOTSET
     formatter = generic
 


### PR DESCRIPTION
If you were to copy and paste from the [Pylons specific documentation](http://raven.readthedocs.org/en/latest/config/pylons.html), you will get the following exception being thrown when attempting to start your `paster`:

``` python
  File "/venv/bin/paster", line 8, in <module>
    load_entry_point('PasteScript==1.7.3', 'console_scripts', 'paster')()
  File "/venv/lib/python2.7/site-packages/paste/script/command.py", line 84, in run
    invoke(command, command_name, options, args[1:])
  File "/venv/lib/python2.7/site-packages/paste/script/command.py", line 123, in invoke
    exit_code = runner.run(args)
  File "/venv/lib/python2.7/site-packages/paste/script/command.py", line 218, in run
    result = self.command()
  File "/venv/lib/python2.7/site-packages/paste/script/serve.py", line 271, in command
    self.logging_file_config(log_fn)
  File "/venv/lib/python2.7/site-packages/paste/script/command.py", line 757, in logging_file_config
    fileConfig(config_file)
  File "/usr/local/lib/python2.7/logging/config.py", line 78, in fileConfig
    handlers = _install_handlers(cp, formatters)
  File "/usr/local/lib/python2.7/logging/config.py", line 156, in _install_handlers
    h = klass(*args)
  File "/venv/lib/python2.7/site-packages/raven/handlers/logging.py", line 49, in __init__
    self.client = client(*args, **kwargs)
TypeError: __init__() takes at most 3 arguments (11 given)
```

Upon investigation, it seems that a **trailing comma** is missing from the `args` value.
