### PR TITLE
Add allow_failures to .travis.yml matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,9 @@ notifications:
     on_success: change
     on_failure: change
 matrix:
+  allow_failures:
+    - env: 'DJANGO="-e git+git://github.com/django/django.git#egg=Django"'
+    - python: "3.4"
   exclude:
     - python: "3.2"
       env: DJANGO=Django==1.4.10

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 Raven
 ======
 
+.. image:: https://travis-ci.org/getsentry/raven-python.svg?branch=master
+    :target: https://travis-ci.org/getsentry/raven-python
+
 Raven is a Python client for `Sentry <http://www.getsentry.com/>`_. It provides
 full out-of-the-box support for many of the popular frameworks, including
 Django, and Flask. Raven also includes drop-in support for any WSGI-compatible


### PR DESCRIPTION
Previously, the failure to compile against a development version of django would fail the entire build. This makes that a development version that is allowed to fail without failing the entire build.

This makes it easier to showcase the stability of the project, and see when pull requests actually break things (compared to everything always failing).

I have also taken the opportunity to add python 3.4 to the allowed failures, since you do not seem to be compatible with it, this would be removed from `allow_failures` when you are ready to support it.

---

Note, this pull request is highly subjective and I will take no offense if you choose to reject it. It just seemed beneficial to better utilize your existing CI setup.
