### PR TITLE
fixed instantiation of UnicodeDecodeError in force_text

### DIFF
--- a/raven/utils/encoding.py
+++ b/raven/utils/encoding.py
@@ -55,7 +55,7 @@ def force_text(s, encoding='utf-8', strings_only=False, errors='strict'):
             s = s.decode(encoding, errors)
     except UnicodeDecodeError as e:
         if not isinstance(s, Exception):
-            raise UnicodeDecodeError(s, *e.args)
+            raise UnicodeDecodeError(*e.args)
         else:
             # If we get to here, the caller has passed in an Exception
             # subclass populated with non-ASCII bytestring data without a


### PR DESCRIPTION
this seems to be a leftover from copying Django's force_text
function
(https://github.com/django/django/blob/master/django/utils/encoding.py#L98).
Note that Django uses its own DjangoUnicodeDecodeError that stores obj
on itself and then calls the super class without obj.

The bug doesn't really have an impact, since the `TypeError` thrown by using the wrong arguments is catched in `to_unicode` with a generic `except Exception`.
