### PR TITLE
Set the test_suite variable to avoid TypeError in setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,12 @@ tests_require = [
 
 
 class PyTest(TestCommand):
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.test_suite = 'tests'
+
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_suite = True
 
     def run_tests(self):
         #import here, cause outside the eggs aren't loaded


### PR DESCRIPTION
When running 'python setup.py test' or 'tox' under Python 2.7 in both Ubuntu and in MacOS, I would get these errors:

```
$ python setup.py test
running test
Traceback (most recent call last):
  File "setup.py", line 134, in <module>
    'Programming Language :: Python :: 3.2',
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/Users/stanhu/.virtualenvs/raven/lib/python2.7/site-packages/setuptools/command/test.py", line 136, in run
    cmd = ' '.join(self.test_args)
TypeError: sequence item 1: expected string, NoneType found
```

It turns out this was happening because **self.test_args** was **['-v', None]**. The extra None parameter was inserted when both self.test_suite and self.distribution.test_suite were set to None.

I'm not sure how this ever worked before, but setting the test_suite variable fixed the issue for me.