### PR TITLE
Fix getting error data from django template.

### DIFF
--- a/raven/contrib/django/utils.py
+++ b/raven/contrib/django/utils.py
@@ -42,14 +42,14 @@ def get_data_from_template(source):
 
     return {
         'template': {
-            'filename': origin.loadname,
+            'filename': getattr(origin, 'loadname', None),
             'abs_path': origin.name,
             'pre_context': pre_context,
             'context_line': context_line,
             'lineno': lineno,
             'post_context': post_context,
         },
-        'culprit': origin.loadname,
+        'culprit': getattr(origin, 'loadname', None),
     }
 
 


### PR DESCRIPTION
StringOrigin instances don't have loadname attribute.
