### PR TITLE
Fix #413 Dont try to auto discover stacktrace for exceptions.

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -279,9 +279,6 @@ class Client(object):
         data.setdefault('tags', {})
         data.setdefault('extra', {})
 
-        if stack is None:
-            stack = self.auto_log_stacks
-
         if '.' not in event_type:
             # Assume it's a builtin
             event_type = 'raven.events.%s' % event_type
@@ -297,6 +294,10 @@ class Client(object):
         for k, v in six.iteritems(result):
             if k not in data:
                 data[k] = v
+
+        if stack is None:
+            stack = (self.auto_log_stacks and
+                     event_type != 'raven.events.Exception')
 
         if stack and 'stacktrace' not in data:
             if stack is True:


### PR DESCRIPTION
auto_discover of stacks doesn't work for exceptions, so I am disabling it explicitly. 
