### PR TITLE
Fix djcelery dependency for Celery 3.1

### DIFF
--- a/raven/contrib/django/celery/models.py
+++ b/raven/contrib/django/celery/models.py
@@ -9,8 +9,11 @@ from __future__ import absolute_import
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from celery import VERSION
 
-if 'djcelery' not in settings.INSTALLED_APPS:
+djcelery_required = not (VERSION[0] == 3 and VERSION[1] >= 1)
+
+if djcelery_required and 'djcelery' not in settings.INSTALLED_APPS:
     raise ImproperlyConfigured(
         "Put 'djcelery' in your INSTALLED_APPS setting in order to use the "
         "sentry celery client.")

--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -18,6 +18,7 @@ import warnings
 
 from raven.utils import six
 
+from celery import VERSION as CELERY_VERSION
 from django.conf import settings as django_settings
 
 logger = logging.getLogger('sentry.errors.client')
@@ -203,8 +204,10 @@ def register_handlers():
     # Connect to Django's internal signal handler
     got_request_exception.connect(exception_handler, weak=False)
 
+    djcelery_not_required = CELERY_VERSION[0] == 3 and CELERY_VERSION[1] >= 1
+
     # If Celery is installed, register a signal handler
-    if 'djcelery' in django_settings.INSTALLED_APPS:
+    if djcelery_not_required or 'djcelery' in django_settings.INSTALLED_APPS:
         try:
             # Celery < 2.5? is not supported
             from raven.contrib.celery import (


### PR DESCRIPTION
`Celery 3.1` doesn't depend on `djcelery` to work with Django anymore.

This pull request is aiming to fix bug described in https://github.com/getsentry/raven-python/issues/427.
I've tested it with `celery==3.1.10` and `sentry==6.4.4`.
