### PR TITLE
setup.py: Remove python-coveralls requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ tests_require = [
     'pytest',
     'pytest-cov>=1.4',
     'pytest-django',
-    'python-coveralls',
     'tornado',
     'webob',
     'webtest',


### PR DESCRIPTION
We haven't used coveralls since 5eba8861 (remove coveralls,
2013-12-10), so there's no sense in asking pip to install it.
