### PR TITLE
Correct keys on frame locals

### DIFF
--- a/raven/utils/stacks.py
+++ b/raven/utils/stacks.py
@@ -246,7 +246,7 @@ def get_stack_info(frames, transformer=transform, capture_locals=True,
             try:
                 f_locals = to_dict(f_locals)
             except Exception:
-                f_locals = None
+                capture_locals = False
 
         frame_result = {
             'abs_path': abs_path,
@@ -256,7 +256,10 @@ def get_stack_info(frames, transformer=transform, capture_locals=True,
             'lineno': lineno + 1,
         }
         if capture_locals:
-            frame_result['vars'] = transformer(f_locals)
+            frame_result['vars'] = dict(
+                (k, transformer(v))
+                for k, v in six.iteritems(f_locals)
+            )
 
         if context_line is not None:
             frame_result.update({

--- a/tests/utils/stacks/tests.py
+++ b/tests/utils/stacks/tests.py
@@ -63,13 +63,13 @@ class GetStackInfoTest(TestCase):
         assert 'vars' in result
         if six.PY3:
             expected = {
-                "'foo'": "'bar'",
-                "'biz'": "'baz'",
+                "foo": "'bar'",
+                "biz": "'baz'",
             }
         else:
             expected = {
-                "u'foo'": "u'bar'",
-                "u'biz'": "u'baz'",
+                "foo": "u'bar'",
+                "biz": "u'baz'",
             }
         assert result['vars'] == expected
 


### PR DESCRIPTION
There are no unicode variable names in Python, which would imply that these keys are non-variant and we don't need to show the repr() in Sentry.
