### PR TITLE
possible fix for #504

### DIFF
--- a/tests/transport/tests.py
+++ b/tests/transport/tests.py
@@ -63,7 +63,7 @@ class TransportTest(TestCase):
         actual_message = zlib.decompress(base64.b64decode(mock_cls._data))
 
         # These loads()/dumps() pairs order the dict keys before comparing the string.
-        # See GH503
+        # See GH504
         self.assertEqual(
             json.dumps(json.loads(expected_message.decode('utf-8')), sort_keys=True),
             json.dumps(json.loads(actual_message.decode('utf-8')), sort_keys=True)


### PR DESCRIPTION
It's a bit hackish, but should prevent all those random build failures.

Let me know if you want me to find a more elegant way to compare decoded strings.  json encoding, then ordered decoding seems to work here...
