### PR TITLE
let flask wrapper configure tags via SENTRY_TAGS

### DIFF
--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -45,6 +45,7 @@ def make_client(client_cls, app, dsn=None):
         string_max_length=app.config.get('SENTRY_MAX_LENGTH_STRING'),
         list_max_length=app.config.get('SENTRY_MAX_LENGTH_LIST'),
         auto_log_stacks=app.config.get('SENTRY_AUTO_LOG_STACKS'),
+        tags=app.config.get('SENTRY_TAGS'),
         extra={
             'app': app,
         },


### PR DESCRIPTION
This adds support for sending tags specified by the flask config option SENTRY_TAGS to the built client. This brings consistency and is implied by the documentation.
