### PR TITLE
prevent label clashes in Django 1.7

### DIFF
--- a/raven/contrib/django/__init__.py
+++ b/raven/contrib/django/__init__.py
@@ -7,4 +7,6 @@ raven.contrib.django
 """
 from __future__ import absolute_import
 
+default_app_config = 'raven.contrib.django.apps.RavenConfig'
+
 from .client import DjangoClient  # NOQA

--- a/raven/contrib/django/apps.py
+++ b/raven/contrib/django/apps.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from django.apps import AppConfig
+
+class RavenConfig(AppConfig):
+    name = 'raven.contrib.django'
+    label = 'raven.contrib.django'
+    verbose_name = 'Raven'


### PR DESCRIPTION
if there are multiple apps in the same project that end with `.django` there will be a label clash.

http://stackoverflow.com/questions/24319558/how-to-resolve-django-core-exceptions-improperlyconfigured-application-labels
