### PR TITLE
Handle streaming requests.

### DIFF
--- a/raven/utils/json.py
+++ b/raven/utils/json.py
@@ -44,9 +44,9 @@ def better_decoder(data):
     return data
 
 
-def dumps(value, **kwargs):
+def dumps(value, cls=BetterJSONEncoder, **kwargs):
     try:
-        return json.dumps(value, cls=BetterJSONEncoder, **kwargs)
+        return json.dumps(value, cls=cls, **kwargs)
     except Exception:
         kwargs['encoding'] = 'safe-utf-8'
         return json.dumps(value, cls=BetterJSONEncoder, **kwargs)


### PR DESCRIPTION
In Tornado RequestHandler classes decorated with the stream_request_body
decorator, the request body may be a Future instance rather than a
string, which breaks currently breaks JSON serialization. This patch
uses a modified JSON encoder for the Tornado module to handle this case
and adds a test to prevent regressions.
