### PR TITLE
__getattribute__ -> getattr

### DIFF
--- a/raven/utils/serializer/base.py
+++ b/raven/utils/serializer/base.py
@@ -21,7 +21,7 @@ __all__ = ('Serializer',)
 
 def has_sentry_metadata(value):
     try:
-        return callable(value.__getattribute__('__sentry__'))
+        return callable(getattr(value, '__sentry__'))
     except Exception:
         return False
 


### PR DESCRIPTION
Replace `__getattribute__` call with getattr call. Or is there a good reason for doing otherwise?
