### PR TITLE
Replace obsolete web client in Twisted transport

### DIFF
--- a/raven/transport/twisted.py
+++ b/raven/transport/twisted.py
@@ -45,7 +45,8 @@ class TwistedHTTPTransport(AsyncTransport, HTTPTransport):
 
     def async_send(self, data, headers, success_cb, failure_cb):
         d = self._agent.request(
-            "POST", self._url, bodyProducer=FileBodyProducer(io.BytesIO(data)),
+            b"POST", self._url,
+            bodyProducer=FileBodyProducer(io.BytesIO(data)),
             headers=Headers(dict((k, [v]) for k, v in headers.items()))
         )
         d.addCallback(lambda r: success_cb())


### PR DESCRIPTION
Raven currently uses an obsolete API to do its HTTP(S) requests.

Using the “new” Agent API adds the following features:

1. Certificate and hostname validation (current implementation is MITMable).
2. A persistent HTTP pool.

I’m not sure how much of a deal 1. is WRT to backward-compatibility (people are known to run broken TLS setups after all).

I would have written tests but turns out, that Raven has no tests for its Twisted transport.  FWIW, there’s a py.test plugin to run Twisted tests: https://pypi.python.org/pypi/pytest-twisted/ but I’m not sure if you want to add it to your suite.