### PR TITLE
Stop loading unittest(2) during normal operation

### DIFF
--- a/raven/utils/compat.py
+++ b/raven/utils/compat.py
@@ -46,8 +46,3 @@ except ImportError:
     from urllib import parse as _urlparse  # NOQA
 
 urlparse = _urlparse
-
-try:
-    from unittest2 import TestCase
-except ImportError:
-    from unittest import TestCase  # NOQA

--- a/raven/utils/testutils.py
+++ b/raven/utils/testutils.py
@@ -9,7 +9,10 @@ from __future__ import absolute_import
 
 from exam import Exam
 
-from .compat import TestCase as BaseTestCase
+try:
+    from unittest2 import TestCase as BaseTestCase
+except ImportError:
+    from unittest import TestCase as BaseTestCase  # NOQA
 
 
 class TestCase(Exam, BaseTestCase):

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -2,7 +2,7 @@ import fnmatch
 import os
 
 from subprocess import call
-from raven.utils.compat import TestCase
+from raven.utils.testutils import BaseTestCase as TestCase
 
 
 ROOT = os.path.normpath(


### PR DESCRIPTION
On my system with CPython 2.7.3 it saves 1.1 MB (16.1 vs 17.2) of memory and 60 imports
when importing raven.handlers.logging.

I know it's negligible change in most cases but I think it's a small price for making it slightly lighter.