### PR TITLE
Change suggested usage of 404CatchMiddleware

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -122,10 +122,14 @@ addition of an optional ``request`` key in the extra data::
 In certain conditions you may wish to log 404 events to the Sentry server. To
 do this, you simply need to enable a Django middleware::
 
-    MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + (
+    MIDDLEWARE_CLASSES = (
       'raven.contrib.django.raven_compat.middleware.Sentry404CatchMiddleware',
       ...,
-    )
+    ) + MIDDLEWARE_CLASSES
+    
+It is recommended to put the middleware at the top, so that any only 404s 
+that bubbled all the way up get logged. Certain middlewares (e.g. flatpages)
+capture 404s and replace the response.
 
 Message References
 ------------------


### PR DESCRIPTION
I ran into an issue with the Sentry middleware logging 404s that we couldn't reproduce in the frontend. It turned out that one of our middlewares was working as expected by catching certain 404s, but as we followed the Raven docs, Sentry reported a 404 for it nonetheless. 
I posted a slightly more elaborate version of what's going here: https://stackoverflow.com/a/28343606/753738