### PR TITLE
Proxy documentation for Flask

### DIFF
--- a/docs/integrations/flask.rst
+++ b/docs/integrations/flask.rst
@@ -100,3 +100,13 @@ This allow to present the user an error ID if have done a custom error 500 page.
     {% if g.sentry_event_id %}
     <p>The error identifier is {{ g.sentry_event_id }}</p>
     {% endif %}
+
+Dealing with proxies
+--------------------
+
+When the Flask app is behind a proxy such as nginx, Sentry will use the remote address from the proxy, rather than from the actual requesting computer.
+By using ``ProxyFix`` from ```werkzeug.contrib.fixers`` <http://werkzeug.pocoo.org/docs/0.10/contrib/fixers/#werkzeug.contrib.fixers.ProxyFix>`_ the Flask ``.wsgi_app`` can be `modified <http://flask.pocoo.org/docs/0.10/deploying/wsgi-standalone/#proxy-setups>`_.
+This may also require changes to the proxy configuration to pass the right headers if it isn't doing so already.
+
+    from werkzeug.contrib.fixers import ProxyFix
+    app.wsgi_app = ProxyFix(app.wsgi_app)

--- a/docs/integrations/flask.rst
+++ b/docs/integrations/flask.rst
@@ -104,9 +104,10 @@ This allow to present the user an error ID if have done a custom error 500 page.
 Dealing with proxies
 --------------------
 
-When the Flask app is behind a proxy such as nginx, Sentry will use the remote address from the proxy, rather than from the actual requesting computer.
-By using ``ProxyFix`` from ```werkzeug.contrib.fixers`` <http://werkzeug.pocoo.org/docs/0.10/contrib/fixers/#werkzeug.contrib.fixers.ProxyFix>`_ the Flask ``.wsgi_app`` can be `modified <http://flask.pocoo.org/docs/0.10/deploying/wsgi-standalone/#proxy-setups>`_.
-This may also require changes to the proxy configuration to pass the right headers if it isn't doing so already.
+When your Flask application is behind a proxy such as nginx, Sentry will use the remote address from the proxy, rather than from the actual requesting computer.
+By using ``ProxyFix`` from `werkzeug.contrib.fixers <http://werkzeug.pocoo.org/docs/0.10/contrib/fixers/#werkzeug.contrib.fixers.ProxyFix>`_ the Flask ``.wsgi_app`` can be modified to send the actual ``REMOTE_ADDR`` along to Sentry. ::
 
     from werkzeug.contrib.fixers import ProxyFix
     app.wsgi_app = ProxyFix(app.wsgi_app)
+
+This may also require `changes <http://flask.pocoo.org/docs/0.10/deploying/wsgi-standalone/#proxy-setups>`_ to the proxy configuration to pass the right headers if it isn't doing so already.


### PR DESCRIPTION
I [found](https://github.com/abkfenris/baxter-flask/issues/48#issuecomment-73361250) that when Flask was deployed behind a nginx proxy Sentry was receiving the wrong `REMOTE_ADDR` from exceptions. 

By using `ProxyFix` on the `app.wsgi_app` (with nginx forwarding the correct headers) Sentry is able to get the correct `REMOTE_ADDR` from exceptions, and I've added some documentation on how to set that up.