### PR TITLE
Add request body filtering method

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Version 5.3.0
+-------------
+
+* Allow filtering of tornado's request body via overloading `get_sentry_request_body`
+
 Version 5.2.0
 -------------
 

--- a/docs/integrations/tornado.rst
+++ b/docs/integrations/tornado.rst
@@ -94,3 +94,26 @@ Synchronous
         def get(self):
             self.write("You requested the main page")
             self.captureMessage("Request for main page served")
+
+
+Request Body Filtering
+~~~~~~~~~~~
+
+If you expect files or large body sizes, you may want to truncate or otherwise
+filter the body.
+
+.. code-block:: python
+
+    import tornado.web
+    from raven.contrib.tornado import SentryMixin
+
+    class AsyncExampleHandler(SentryMixin, tornado.web.RequestHandler):
+        # Strip files and ensure the body is small enough
+        def get_sentry_request_body(self):
+            if len(self.request.files)>0 or len(self.request.body) > 200000:
+                files = {k:[{dk:dv for dk, dv in d.iteritems() if dk!='body'}for d in v] for k,v in self.request.files.iteritems()}
+                data = { 'arguments': self.request.arguments, 'files': files } 
+            else:
+                data = self.request.body
+
+            return data

--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -175,6 +175,9 @@ class SentryMixin(object):
         """
         return self.application.sentry_client
 
+    def get_sentry_request_body(self):
+        return self.request.body
+
     def get_sentry_data_from_request(self):
         """
         Extracts the data required for 'sentry.interfaces.Http' from the
@@ -186,7 +189,7 @@ class SentryMixin(object):
             'request': {
                 'url': self.request.full_url(),
                 'method': self.request.method,
-                'data': self.request.body,
+                'data': self.get_sentry_request_body(),
                 'query_string': self.request.query,
                 'cookies': self.request.headers.get('Cookie', None),
                 'headers': dict(self.request.headers),

--- a/tests/contrib/tornado/tests.py
+++ b/tests/contrib/tornado/tests.py
@@ -6,6 +6,7 @@ from tornado import web, gen, testing
 from raven.contrib.tornado import SentryMixin, AsyncSentryClient
 from raven.utils import six
 
+body_limit = 5000
 
 class AnErrorProneHandler(SentryMixin, web.RequestHandler):
     def get(self):
@@ -37,9 +38,21 @@ class SendErrorTestHandler(SentryMixin, web.RequestHandler):
 
 
 class SendErrorAsyncHandler(SentryMixin, web.RequestHandler):
+    def get_sentry_request_body(self):
+        body = self.request.body
+        if len(body) > body_limit:
+            return 'Request body is too large!'
+        else:
+            return body
+
     @web.asynchronous
     @gen.engine
     def get(self):
+        raise Exception("Oops")
+    
+    @web.asynchronous
+    @gen.engine
+    def post(self):
         raise Exception("Oops")
 
 
@@ -212,3 +225,24 @@ class TornadoAsyncClientTestCase(testing.AsyncHTTPTestCase):
 
         user_data = kwargs['user']
         self.assertEqual(user_data['is_authenticated'], False)
+
+    @patch('raven.contrib.tornado.AsyncSentryClient.send')
+    def test_large_body_handler(self, send):
+        response = self.fetch('/send-error-async', method="POST", body="x" * (body_limit+1))
+        self.assertEqual(response.code, 500)
+        self.assertEqual(send.call_count, 1)
+        args, kwargs = send.call_args
+
+        assert 'user' in kwargs
+        assert 'request' in kwargs
+        assert 'exception' in kwargs
+
+        http_data = kwargs['request']
+
+        self.assertEqual(http_data['cookies'], None)
+        self.assertEqual(http_data['url'], response.effective_url)
+        self.assertEqual(http_data['query_string'], '')
+        self.assertEqual(http_data['method'], 'POST')
+        self.assertEqual(http_data['data'], 'Body is too large!')
+
+

--- a/tests/contrib/tornado/tests.py
+++ b/tests/contrib/tornado/tests.py
@@ -243,6 +243,6 @@ class TornadoAsyncClientTestCase(testing.AsyncHTTPTestCase):
         self.assertEqual(http_data['url'], response.effective_url)
         self.assertEqual(http_data['query_string'], '')
         self.assertEqual(http_data['method'], 'POST')
-        self.assertEqual(http_data['data'], 'Body is too large!')
+        self.assertEqual(http_data['data'], 'Request body is too large!')
 
 


### PR DESCRIPTION
This adds a simple method that allows graceful filtering of request bodies, so we don't send too much data or files to Sentry.

Originally from #372 