### PR TITLE
Restart threaded http transport worker after a fork

### DIFF
--- a/raven/transport/threaded.py
+++ b/raven/transport/threaded.py
@@ -35,6 +35,9 @@ class AsyncWorker(object):
         }
         self.start()
 
+    def is_alive(self):
+        return self._thread.is_alive()
+
     def main_thread_terminated(self):
         self._lock.acquire()
         try:
@@ -150,7 +153,7 @@ class ThreadedHTTPTransport(AsyncTransport, HTTPTransport):
     scheme = ['http', 'https', 'threaded+http', 'threaded+https']
 
     def get_worker(self):
-        if not hasattr(self, '_worker'):
+        if not hasattr(self, '_worker') or not self._worker.is_alive():
             self._worker = AsyncWorker()
         return self._worker
 

--- a/tests/transport/threaded/tests.py
+++ b/tests/transport/threaded/tests.py
@@ -1,5 +1,8 @@
 import mock
+import os
 import time
+from tempfile import mkstemp
+
 from raven.utils.testutils import TestCase
 
 from raven.base import Client
@@ -19,6 +22,16 @@ class DummyThreadedScheme(ThreadedHTTPTransport):
         time.sleep(self.send_delay)
 
         self.events.append((data, headers, success_cb, failure_cb))
+
+
+class LoggingThreadedScheme(ThreadedHTTPTransport):
+    def __init__(self, filename, *args, **kwargs):
+        super(LoggingThreadedScheme, self).__init__(*args, **kwargs)
+        self.filename = filename
+
+    def send_sync(self, data, headers, success_cb, failure_cb):
+        with open(self.filename, 'a') as log:
+            log.write("{} {}\n".format(os.getpid(), data['message']))
 
 
 class ThreadedTransportTest(TestCase):
@@ -50,3 +63,32 @@ class ThreadedTransportTest(TestCase):
         transport.get_worker().main_thread_terminated()
 
         self.assertEqual(len(transport.events), 1)
+
+    def test_fork_with_active_worker(self):
+        # Test threaded transport when forking with an active worker.
+        # Forking a process doesn't clone the worker thread - make sure
+        # logging from both processes still works.
+        event1 = self.client.build_msg('raven.events.Message', message='parent')
+        event2 = self.client.build_msg('raven.events.Message', message='child')
+        url = urlparse(self.url)
+        _, filename = mkstemp()
+        try:
+            transport = LoggingThreadedScheme(filename, url)
+            # Log from the parent process - starts the worker thread
+            transport.async_send(event1, None, None, None)
+            childpid = os.fork()
+            if childpid == 0:
+                # Log from the child process
+                transport.async_send(event2, None, None, None)
+                time.sleep(0.1)
+                os._exit(0)
+            # Wait for the child process to finish
+            os.waitpid(childpid, 0)
+            self.assertTrue(os.path.isfile(filename))
+            with open(filename, 'r') as logfile:
+                events = dict(x.strip().split() for x in logfile.readlines())
+            # Check parent and child both logged successfully
+            self.assertEqual(events, {str(os.getpid()): 'parent',
+                                      str(childpid): 'child'})
+        finally:
+            os.remove(filename)


### PR DESCRIPTION
Forking a process doesn't clone the threads. If the worker was already active in the parent process, the child process would be stuck with a worker with a stopped thread which wouldn't send any messages.

This is relevant when using Gunicorn in preload mode when messages are already logged in the preload phase:

https://groups.google.com/forum/#!topic/getsentry/2kRU_4lye-E