### PR TITLE
passing loglevel along to handler init

### DIFF
--- a/raven/contrib/celery/__init__.py
+++ b/raven/contrib/celery/__init__.py
@@ -41,7 +41,7 @@ def register_logger_signal(client, logger=None, loglevel=logging.ERROR):
 
     if logger is None:
         logger = logging.getLogger()
-    handler = SentryHandler(client)
+    handler = SentryHandler(client, level=loglevel)
     handler.setLevel(loglevel)
     handler.addFilter(filter_)
 


### PR DESCRIPTION
Hello there, I was experiencing a situation where basically every Celery log was being sent to Sentry, so I  was hoping passing along the logging level to the Handler when it is initialised might help(as the default is NOTSET see https://github.com/getsentry/raven-python/blob/master/raven/handlers/logging.py#L51), although I'm not sure what caused the issue in the first place. Any ideas?