### PR TITLE
json encoding for Decimals and lazy translations

### DIFF
--- a/raven/utils/json.py
+++ b/raven/utils/json.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import codecs
 import datetime
 import uuid
-
+from decimal import Decimal
 try:
     import simplejson as json
 except ImportError:
@@ -30,9 +30,13 @@ class BetterJSONEncoder(json.JSONEncoder):
         set: list,
         frozenset: list,
         bytes: lambda o: o.decode('utf-8', errors='replace'),
+        Decimal: repr
     }
 
     def default(self, obj):
+        if hasattr(obj, '_proxy____text_cast'):
+            # django's gettext_lazy proxy strings
+            return obj.encode('utf8')
         try:
             encoder = self.ENCODER_BY_TYPE[type(obj)]
         except KeyError:

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -21,7 +21,8 @@ from django.core.signals import got_request_exception
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import QueryDict
 from django.template import TemplateSyntaxError
-from django.test import TestCase
+from django.test import TestCase, SimpleTestCase
+from django.utils.translation import gettext_lazy
 
 from raven.base import Client
 from raven.contrib.django.client import DjangoClient
@@ -32,7 +33,7 @@ from raven.contrib.django.middleware.wsgi import Sentry
 from raven.contrib.django.templatetags.raven import sentry_public_dsn
 from raven.contrib.django.views import is_valid_origin
 from raven.utils.serializer import transform
-from raven.utils import six
+from raven.utils import six, json
 from raven.utils.six import StringIO
 
 from django.test.client import Client as TestClient, ClientHandler as TestClientHandler
@@ -777,3 +778,9 @@ class SentryExceptionHandlerTest(TestCase):
         sentry_exception_handler(request=self.request)
 
         assert not captureException.called
+
+
+class JSONTest(SimpleTestCase):
+    def test_translation(self):
+        d = {'lazy_translation': gettext_lazy('testing')}
+        assert json.dumps(d) == '{"lazy_translation": "testing"}'

--- a/tests/utils/json/tests.py
+++ b/tests/utils/json/tests.py
@@ -2,6 +2,7 @@
 
 import datetime
 import uuid
+from decimal import Decimal
 from raven.utils.testutils import TestCase
 
 from raven.utils import json
@@ -32,3 +33,7 @@ class JSONTest(TestCase):
 
         obj = Unknown()
         assert json.dumps(obj) == '"Unknown object"'
+
+    def test_decimal(self):
+        d = {'decimal': Decimal('123.45')}
+        assert json.dumps(d) == '{"decimal": "Decimal(\'123.45\')"}'


### PR DESCRIPTION
I just ran into the problem in a fairly serious situation where raven should have given me details on a error processing payments. Instead if failed because it tried to serialise a django translation string.

I don't see any docs for how to set up a testing environment or run tests so I wasn't able to run this.