### PR TITLE
Fix Eventlet transport on Python 3

### DIFF
--- a/raven/transport/eventlet.py
+++ b/raven/transport/eventlet.py
@@ -13,7 +13,10 @@ from raven.transport.http import HTTPTransport
 
 try:
     import eventlet
-    from eventlet.green import urllib2 as eventlet_urllib2
+    try:
+        from eventlet.green import urllib2 as eventlet_urllib2
+    except ImportError:
+        from eventlet.green.urllib import request as eventlet_urllib2
     has_eventlet = True
 except:
     has_eventlet = False


### PR DESCRIPTION
eventlet.green.urllib* naming and hierarchy reflects the standard
library (2.x: urllib and urllib2, 3.x: just urllib) so there's no
eventlet.green.urllib2 on Python 3.