### PR TITLE
Fix grammar issue in Django docs

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -2,9 +2,10 @@ Django
 ======
 
 .. default-domain:: py
-`Django <http://djangoproject.com/>`_ is arguably Python's most popular web framework.  Support is built into Raven but needs some
-configuration.  While older versions of Django will likely work,
-officially only version 1.4 and newer are supported.
+`Django <http://djangoproject.com/>`_ is arguably Python's most popular web
+framework.  Support is built into Raven but needs some configuration.  While
+older versions of Django will likely work, officially only version 1.4 and
+newer are supported.
 
 Setup
 -----

--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -2,9 +2,7 @@ Django
 ======
 
 .. default-domain:: py
-
-`Django <http://djangoproject.com/>`_ is one of (if not the) Python's most
-popular web frameworks.  Support is built into Raven but needs some
+`Django <http://djangoproject.com/>`_ is arguably Python's most popular web framework.  Support is built into Raven but needs some
 configuration.  While older versions of Django will likely work,
 officially only version 1.4 and newer are supported.
 


### PR DESCRIPTION
remove "(if not the) Python's"