### PR TITLE
Refactor get_version_from_app to better handle unexepcted cases

### DIFF
--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -56,26 +56,30 @@ _VERSION_CACHE = {}
 
 
 def get_version_from_app(module_name, app):
+    version = None
     if hasattr(app, 'get_version'):
-        get_version = app.get_version
-        if callable(get_version):
-            version = get_version()
-        else:
-            version = get_version
+        version = app.get_version
     elif hasattr(app, '__version__'):
         version = app.__version__
     elif hasattr(app, 'VERSION'):
         version = app.VERSION
     elif hasattr(app, 'version'):
         version = app.version
-    elif pkg_resources:
+
+    if callable(version):
+        version = version()
+
+    if not isinstance(version, (six.string_types, list, tuple)):
+        version = None
+
+    if version is None:
+        if pkg_resources is None:
+            return None
         # pull version from pkg_resources if distro exists
         try:
             version = pkg_resources.get_distribution(module_name).version
         except pkg_resources.DistributionNotFound:
             return None
-    else:
-        return None
 
     if isinstance(version, (list, tuple)):
         version = '.'.join(map(str, version))


### PR DESCRIPTION
For example, graphite's `version` returns a `module`. So this should
cover all of the bases to assure that we don't return back a `str`
of a `module` or any other weird type.