### PR TITLE
Don't send X-Sentry-ID when last_event_id is None

### DIFF
--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -223,7 +223,8 @@ class Sentry(object):
         self.client.user_context(self.get_user_info(request))
 
     def after_request(self, sender, response, *args, **kwargs):
-        response.headers['X-Sentry-ID'] = self.last_event_id
+        if self.last_event_id:
+            response.headers['X-Sentry-ID'] = self.last_event_id
         self.client.context.clear()
         return response
 


### PR DESCRIPTION
Headers with `X-Sentry-ID: None` is useless. It is a waste of bandwidth.