### PR TITLE
add parameter `ignored_exception_types` to the tornado client to allow ignore specific exceptions

### DIFF
--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -19,7 +19,7 @@ class AsyncSentryClient(Client):
     """
     def __init__(self, *args, **kwargs):
         self.validate_cert = kwargs.pop('validate_cert', True)
-        self.ignored_exc_types = kwargs.pop('ignored_exc_types', [])
+        self.ignored_exception_types = kwargs.pop('ignored_exception_types', [])
         super(AsyncSentryClient, self).__init__(*args, **kwargs)
 
     def capture(self, *args, **kwargs):
@@ -226,6 +226,11 @@ class SentryMixin(object):
         log_exception() is added in Tornado v3.1.
         """
         rv = super(SentryMixin, self).log_exception(typ, value, tb)
+
+        client = self.get_sentry_client()
+        if any(typ is ignored_type for ignored_type in client.ignored_exception_types):
+            return
+
         self.captureException(exc_info=(typ, value, tb))
         return rv
 

--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -19,6 +19,7 @@ class AsyncSentryClient(Client):
     """
     def __init__(self, *args, **kwargs):
         self.validate_cert = kwargs.pop('validate_cert', True)
+        self.ignored_exc_types = kwargs.pop('ignored_exc_types', [])
         super(AsyncSentryClient, self).__init__(*args, **kwargs)
 
     def capture(self, *args, **kwargs):


### PR DESCRIPTION
We've deployed sentry to our website recently, but soon get flooded with exceptions like `HTTPError: HTTP 404: Not Found`. It would be cool for us to ignore them.

There's a option `RAVEN_IGNORE_EXCEPTIONS` in the flask client, but haven't the equivalent in the tornado client yet. This PR is a copycat about this option:

```
        app.sentry_client = AsyncSentryClient(
            '__DSN__',
            ignored_exception_types=[HTTPError],
        )
```

Regards.