### PR TITLE
In order to prepare the compatibility with the Django 1.9

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -14,7 +14,13 @@ from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.http import HttpRequest
 from django.template import TemplateSyntaxError
-from django.template.loader import LoaderOrigin
+
+try:
+    # support Django 1.9
+    from django.template.base import Origin
+except ImportError:
+    # backward compatibility
+    from django.template.loader import LoaderOrigin as Origin
 
 from raven.base import Client
 from raven.contrib.django.utils import get_data_from_template, get_host
@@ -148,7 +154,7 @@ class DjangoClient(Client):
             # As of r16833 (Django) all exceptions may contain a ``django_template_source`` attribute (rather than the
             # legacy ``TemplateSyntaxError.source`` check) which describes template information.
             if hasattr(exc_value, 'django_template_source') or ((isinstance(exc_value, TemplateSyntaxError) and
-               isinstance(getattr(exc_value, 'source', None), (tuple, list)) and isinstance(exc_value.source[0], LoaderOrigin))):
+               isinstance(getattr(exc_value, 'source', None), (tuple, list)) and isinstance(exc_value.source[0], Origin))):
                 source = getattr(exc_value, 'django_template_source', getattr(exc_value, 'source', None))
                 if source is None:
                     self.logger.info('Unable to get template source from exception')


### PR DESCRIPTION
Django 1.9 is aimed to be [in alpha in september](https://code.djangoproject.com/wiki/Version1.9Roadmap). So this PR should at least stay open until September 21, 2015.

The changes are described in the [Django 1.9 release notes](https://docs.djangoproject.com/en/dev/releases/1.9/#template-loaderorigin-and-stringorigin-are-removed).

Cheers