### PR TITLE
add try..except for error on self.get_current_user()

### DIFF
--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -169,9 +169,13 @@ class SentryMixin(object):
         `tornado.web.RequestHandler.get_current_user` tests postitively for on
         Truth calue testing
         """
+        try:
+            user = self.get_current_user()
+        except Exception:
+            return {}
         return {
             'user': {
-                'is_authenticated': True if self.get_current_user() else False
+                'is_authenticated': True if user else False
             }
         }
 


### PR DESCRIPTION
We had overrided get_current_user() which might raise an AttributeError, and it would break sentry's  get_default_context() like below:

```
...
  File "~/raven/contrib/tornado/__init__.py", line 205, in _capture
    data = self.get_default_context()
  File "~/raven/contrib/tornado/__init__.py", line 196, in get_default_context
    data.update(self.get_sentry_user_info())
  File "~/raven/contrib/tornado/__init__.py", line 175, in get_sentry_user_info
    'is_authenticated': True if self.get_current_user() else False
  File "meow/apps/api_v3/controller/__init__.py", line 80, in get_current_user
    user = Storage(us.get_user(self.user_id))
AttributeError: 'ExploreHotTopicAndCollection' object has no attribute 'user_id'
```

Maybe it would be better to catch the unexpected error from get_current_user()? 

Regards.