### PR TITLE
fix issue of inexplicitly concatenating str to unicode in httplib

### DIFF
--- a/raven/transport/eventlet.py
+++ b/raven/transport/eventlet.py
@@ -34,7 +34,7 @@ class EventletHTTPTransport(HTTPTransport):
         self._url = self._url.split('+', 1)[-1]
 
     def _send_payload(self, payload):
-        req = eventlet_urllib2.Request(self._url, headers=payload[1])
+        req = eventlet_urllib2.Request(str(self._url), headers=payload[1])
         try:
             if sys.version_info < (2, 6):
                 response = eventlet_urllib2.urlopen(req, payload[0]).read()

--- a/raven/transport/http.py
+++ b/raven/transport/http.py
@@ -36,7 +36,7 @@ class HTTPTransport(Transport):
         """
         Sends a request to a remote webserver using HTTP POST.
         """
-        req = urllib2.Request(self._url, headers=headers)
+        req = urllib2.Request(str(self._url), headers=headers)
 
         try:
             response = urlopen(


### PR DESCRIPTION
Due to commit a76101f, now encoded post data is a string containing non-ascii character. Which could be a problem where httplib in Python 2.7 tries to concatenating ```message_body``` to ```msg```, since ```msg``` is unicode, ```message_body``` has to be converted to unicode first, however since it is not an ascii string, decoding as ascii would fail and throw an exception.

ref: https://bitbucket.org/jurko/suds/issues/10/unicodeerror-is-raised-when-sending-non