### PR TITLE
Better guessing for head in `fetch_git_sha`

### DIFF
--- a/raven/versioning.py
+++ b/raven/versioning.py
@@ -12,11 +12,20 @@ from .exceptions import InvalidGitRepository
 __all__ = ('fetch_git_sha', 'fetch_package_version')
 
 
-def fetch_git_sha(path, head='master'):
+def fetch_git_sha(path, head=None):
     """
     >>> fetch_git_sha(os.path.dirname(__file__))
     """
-    revision_file = os.path.join(path, '.git', 'refs', 'heads', head)
+    if not head:
+        try:
+            head = open(os.path.join(path, '.git', 'HEAD'), 'r')
+            revision_file = os.path.join(
+                path, '.git', *head.read().strip().split(' ')[1].split('/')
+            )
+        finally:
+            head.close()
+    else:
+        revision_file = os.path.join(path, '.git', 'refs', 'heads', head)
     if not os.path.exists(revision_file):
         if not os.path.exists(os.path.join(path, '.git')):
             raise InvalidGitRepository('%s does not seem to be the root of a git repository' % (path,))

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ tests_require = [
     'pytz',
     'pytest>=2.7.0,<2.8.0',
     'pytest-cov>=1.4',
-    'pytest-django>=2.8.0,<2.7.0',
+    'pytest-django>=2.7.0,<2.8.0',
     'pytest-timeout==0.4',
     'requests',
     'tornado',

--- a/tests/versioning/tests.py
+++ b/tests/versioning/tests.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import os.path
 import pytest
+import subprocess
 
 from django.conf import settings
 
@@ -19,6 +20,9 @@ def test_fetch_git_sha():
     assert result is not None
     assert len(result) == 40
     assert isinstance(result, six.string_types)
+    assert result == subprocess.check_output(
+        'git rev-parse --verify HEAD', shell=True, cwd=settings.PROJECT_ROOT
+    ).strip()
 
 
 def test_fetch_package_version():


### PR DESCRIPTION
Currently, `fetch_git_sha` takes `master` branch as the default `HEAD`, while this is not true for many cases - like `develop` branches, feature branches etc.

This implementation uses a smarter default and takes the `HEAD` to use from the `.git/HEAD` file.

Also, includes a - possible typo - fix in the dependencies for tests in `setup.py` and an improved test to test this new behavior - where the previous implementation would fail.