### PR TITLE
Pass the required parsed_url parameter back to HTTPTransport

### DIFF
--- a/raven/transport/twisted.py
+++ b/raven/transport/twisted.py
@@ -30,7 +30,7 @@ class TwistedHTTPTransport(AsyncTransport, HTTPTransport):
         if not has_twisted:
             raise ImportError('TwistedHTTPTransport requires twisted.web.')
 
-        super(TwistedHTTPTransport, self).__init__(*args, **kwargs)
+        super(TwistedHTTPTransport, self).__init__(parsed_url, *args, **kwargs)
 
         # Import reactor as late as possible.
         from twisted.internet import reactor


### PR DESCRIPTION
Without this I'm getting this traceback:
```
  File ".../raven/transport/twisted.py", line 33, in __init__
    super(TwistedHTTPTransport, self).__init__(*args, **kwargs)
exceptions.TypeError: __init__() takes at least 2 arguments (1 given)
```