### PR TITLE
Submit coverage reports to Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,14 @@ env:
 
 install:
   - time ci/setup
+  - pip install codecov
 
 script:
   - "if [[ ${TRAVIS_PYTHON_VERSION} != 'pypy' ]]; then make lint; fi"
   - py.test tests/ --cov raven --cov-report term-missing --timeout 10
+
+after_success:
+  - codecov -e DJANGO
 
 matrix:
   allow_failures:


### PR DESCRIPTION
> Hey there, Steve from [Codecov](https://codecov.io) here. 
> We will now be using Sentry to track our bugs in Codecov. I figured to create a pull request to add our hosted coverage service to this project.

You can see a [sample report here](https://codecov.io/github/stevepeak/raven-python/raven?ref=4af7a1b009c01dd2ce242ed54ad5195bec3a7dff). Let me know if you have any questions about the service :)

The `-e DJANGO` will track the Django var in the build reports, [as seen here](https://codecov.io/github/stevepeak/raven-python/raven?ref=4af7a1b009c01dd2ce242ed54ad5195bec3a7dff&build=3.2)

Cheers,
Steve