### PR TITLE
Fix issue user_info is populated but not returned when SENTRY_USER_ATTRS is populated

### DIFF
--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -172,6 +172,8 @@ class Sentry(object):
                 if hasattr(current_user, attr):
                     user_info[attr] = getattr(current_user, attr)
 
+        return user_info
+
     def get_http_info(self, request):
         """
         Determine how to retrieve actual data by using request.mimetype.


### PR DESCRIPTION
This pull request basically adds a single return statement in `get_user_info` method when `SENTRY_USER_ATTRS` is specified. It also fixes the `test_user` testcase to actually test if the user context in error event actually contains the specified attributes in `SENTRY_USER_ATTRS`