### PR TITLE
Detected installed version instead of declared version when possible

### DIFF
--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -57,6 +57,16 @@ _VERSION_CACHE = {}
 
 def get_version_from_app(module_name, app):
     version = None
+
+    # Try to pull version from pkg_resource first
+    # as it is able to detect version tagged with egg_info -b
+    if pkg_resources is not None:
+        # pull version from pkg_resources if distro exists
+        try:
+            return pkg_resources.get_distribution(module_name).version
+        except pkg_resources.DistributionNotFound:
+            pass
+
     if hasattr(app, 'get_version'):
         version = app.get_version
     elif hasattr(app, '__version__'):
@@ -73,13 +83,7 @@ def get_version_from_app(module_name, app):
         version = None
 
     if version is None:
-        if pkg_resources is None:
-            return None
-        # pull version from pkg_resources if distro exists
-        try:
-            version = pkg_resources.get_distribution(module_name).version
-        except pkg_resources.DistributionNotFound:
-            return None
+        return None
 
     if isinstance(version, (list, tuple)):
         version = '.'.join(map(str, version))


### PR DESCRIPTION
This pull-request try to detect version with pkg_resources first as it is able to detected installed version instead of declared one.

Main use case is version tagged with ``egg_info -b $TAG`` which is not written in ``__version__`` but detected by pkg_resources.

Our continuous integration versionning heavily rely on this mecanism: ``__version__`` contains 0.1.dev and we release ``python setup.py egg_info -b $TAG bdist_wheel`` which produce a package with version ``0.1.dev$TAG`` but which is currently detected ``0.1.dev`` by raven/sentry.