### PR TITLE
Use cached_property for getting client in the Django middleware

### DIFF
--- a/raven/contrib/django/middleware/wsgi.py
+++ b/raven/contrib/django/middleware/wsgi.py
@@ -7,13 +7,14 @@ raven.contrib.django.middleware.wsgi
 """
 from __future__ import absolute_import
 
+from django.utils.functional import cached_property
 from raven.middleware import Sentry
 
 
 class Sentry(Sentry):
     """
     Identical to the default WSGI middleware except that
-    the client comes dynamically via ``get_client
+    the client comes dynamically via ``get_client``
 
     >>> from raven.contrib.django.middleware.wsgi import Sentry
     >>> application = Sentry(application)
@@ -21,7 +22,7 @@ class Sentry(Sentry):
     def __init__(self, application):
         self.application = application
 
-    @property
+    @cached_property
     def client(self):
         from raven.contrib.django.models import client
         return client


### PR DESCRIPTION
Since we need to lazy import the client inside the `@property`, we incur
the overhead of importing every time.

This overhead is minimal, ~0.7usec on my machine, but this is done on
every request, 3 times per request which adds up to ~2.1usec.

As a `@cached_property`, this gets transformed directly into the __dict__
of the instance, and brings the time down to ~0.04usec per lookup, which
is over an order of magnitude faster after the initial call.

Also, worth noting, `cached_property` was added in Django 1.4, and 1.4 is the oldest we test against in Travis, so I assume this is the oldest that we support. If not, I can `try...except ImportError` and fallback.