### PR TITLE
Handle non-text dictionary keys when sanitizing data.

### DIFF
--- a/raven/processors.py
+++ b/raven/processors.py
@@ -94,7 +94,7 @@ class SanitizePasswordsProcessor(Processor):
         if not key:  # key can be a NoneType
             return value
 
-        key = key.lower()
+        key = six.text_type(key).lower()
         for field in self.FIELDS:
             if field in key:
                 # store mask as a fixed length for security


### PR DESCRIPTION
The sanitizing process assumes that keys being checked are string types. There can however be dictionaries with integers or other immutable types (e.g. tuples) as keys. These lead to exceptions such as
```
AttributeError("'int' object has no attribute 'lower'",) 
```

This PR converts keys before proceeding (e.g. calling ``lower()``). It also includes a test extension for a nested dictionary.