### PR TITLE
Ensure Django LOGGING example passes PEP8

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -97,7 +97,7 @@ following config can be used::
         'handlers': {
             'sentry': {
                 'level': 'ERROR',
-                'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+                'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler'
             },
             'console': {
                 'level': 'DEBUG',


### PR DESCRIPTION
In this LOGGING example, the last comma is not always kept. After copy-pasting this into the Django configuration, I had to remove this specific comma to fit in 80 characters. Maybe that's worth it?