### PR TITLE
Log SystemExit in wsgi middleware when code != 0

### DIFF
--- a/raven/middleware.py
+++ b/raven/middleware.py
@@ -36,12 +36,20 @@ class Sentry(object):
         except Exception:
             self.handle_exception(environ)
             raise
+        except SystemExit as e:
+            if e.code != 0:
+                self.handle_exception(environ)
+            raise
 
         try:
             for event in iterable:
                 yield event
         except Exception:
             self.handle_exception(environ)
+            raise
+        except SystemExit as e:
+            if e.code != 0:
+                self.handle_exception(environ)
             raise
         finally:
             # wsgi spec requires iterable to call close if it exists
@@ -51,6 +59,10 @@ class Sentry(object):
                     iterable.close()
                 except Exception:
                     self.handle_exception(environ)
+                except SystemExit as e:
+                    if e.code != 0:
+                        self.handle_exception(environ)
+                    raise
             self.client.context.clear()
 
     def get_http_context(self, environ):


### PR DESCRIPTION
SystemExit does not subclass Exception, so we don't catch this.
SystemExit manifests itself (at least) from gunicorn when gunicorn
attempts to gracefully shut down a worker process. See GH-675 for more
background.

Fixes: GH-675