### PR TITLE
Support detached HEAD in fetch_git_sha

### DIFF
--- a/raven/versioning.py
+++ b/raven/versioning.py
@@ -32,7 +32,7 @@ def fetch_git_sha(path, head=None):
                 path, '.git', *head.rsplit(' ', 1)[-1].split('/')
             )
         else:
-            revision_file = os.path.join(path, '.git', head)
+            return head
     else:
         revision_file = os.path.join(path, '.git', 'refs', 'heads', head)
 


### PR DESCRIPTION
Quick fix for #676. Unsure if this might break some other case – but it seems to work when the HEAD contains `ref: ...` or an SHA.