### PR TITLE
Django handler: add support for tags in logging setup

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -98,6 +98,7 @@ following config can be used::
             'sentry': {
                 'level': 'ERROR',
                 'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler'
+                'tags': {'custom-tag': 'x'},
             },
             'console': {
                 'level': 'DEBUG',

--- a/raven/contrib/django/handlers.py
+++ b/raven/contrib/django/handlers.py
@@ -13,8 +13,9 @@ from raven.handlers.logging import SentryHandler as BaseSentryHandler
 
 
 class SentryHandler(BaseSentryHandler):
-    def __init__(self, level=logging.NOTSET):
+    def __init__(self, level=logging.NOTSET, tags=None):
         logging.Handler.__init__(self, level=level)
+        self.tags = tags
 
     def _get_client(self):
         from raven.contrib.django.models import client
@@ -25,5 +26,7 @@ class SentryHandler(BaseSentryHandler):
 
     def _emit(self, record):
         request = getattr(record, 'request', None)
+        if self.tags is not None and not hasattr(record, 'tags'):
+            record.tags = self.tags
 
         return super(SentryHandler, self)._emit(record, request=request)


### PR DESCRIPTION
I find it useful to have various sentry handlers in Django (one for general exceptions, another one for logging slow queries) and to make it easier to group the outputs, I added custom tags support for Django logging settings.