### PR TITLE
Catch the RuntimeError raised if contentypes is not available

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -52,15 +52,19 @@ class DjangoClient(Client):
         return user_info
 
     def get_data_from_request(self, request):
+        result = {}
+
         try:
             from django.contrib.auth.models import AbstractBaseUser as BaseUser
         except ImportError:
             from django.contrib.auth.models import User as BaseUser  # NOQA
-
-        result = {}
-
-        if hasattr(request, 'user') and isinstance(request.user, BaseUser):
-            result['user'] = self.get_user_info(request.user)
+        except RuntimeError:
+            # If the contenttype / user applications are not installed trying to
+            # import the user models will fail for django >= 1.9.
+            pass
+        else:
+            if hasattr(request, 'user') and isinstance(request.user, BaseUser):
+                result['user'] = self.get_user_info(request.user)
 
         try:
             uri = request.build_absolute_uri()


### PR DESCRIPTION
In Django 1.9 it became an error to import a model of an app
before it is loaded (https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9)

This means the import of the user model may fail if the contenttype
or user contrib applications are not in INSTALLED_APPS.

Fixes #705