### PR TITLE
Do not capture tornado.web.HTTPErrors if their status code is not 5xx

### DIFF
--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -11,6 +11,7 @@ from functools import partial
 
 from tornado import ioloop
 from tornado.httpclient import AsyncHTTPClient, HTTPError
+from tornado import web
 
 from raven.base import Client
 
@@ -227,6 +228,9 @@ class SentryMixin(object):
         log_exception() is added in Tornado v3.1.
         """
         rv = super(SentryMixin, self).log_exception(typ, value, tb)
+        # Do not capture web.HTTPErrors outside the 500 range.
+        if isinstance(value, web.HTTPError) and (value.status_code < 500 or value.status_code > 599):
+            return rv
         self.captureException(exc_info=(typ, value, tb))
         return rv
 

--- a/tests/contrib/tornado/tests.py
+++ b/tests/contrib/tornado/tests.py
@@ -62,6 +62,11 @@ class AsyncMessageHandler(SentryMixin, web.RequestHandler):
         }
 
 
+class HTTPErrorHandler(SentryMixin, web.RequestHandler):
+    def get(self):
+        raise web.HTTPError(int(self.get_query_argument('code', 500)), "Oops")
+
+
 class TornadoAsyncClientTestCase(testing.AsyncHTTPTestCase):
     def get_app(self):
         app = web.Application([
@@ -71,6 +76,7 @@ class TornadoAsyncClientTestCase(testing.AsyncHTTPTestCase):
             web.url(r'/send-error-async', SendErrorAsyncHandler),
             web.url(r'/an-error-with-custom-non-dict-data', AnErrorWithCustomNonDictData),
             web.url(r'/an-error-with-custom-dict-data', AnErrorWithCustomDictData),
+            web.url(r'/http-error', HTTPErrorHandler)
         ])
         app.sentry_client = AsyncSentryClient(
             'http://public_key:secret_key@host:9000/project'
@@ -237,3 +243,29 @@ class TornadoAsyncClientTestCase(testing.AsyncHTTPTestCase):
 
                 yield gen.sleep(0.01)  # we need to run after the async send
                 assert mock_failed.called
+
+    @patch('raven.contrib.tornado.AsyncSentryClient.send')
+    def test_http_error_500(self, send):
+        response = self.fetch('/http-error?code=500')
+        self.assertEqual(response.code, 500)
+        self.assertEqual(send.call_count, 1)
+        args, kwargs = send.call_args
+
+        assert 'user' in kwargs
+        assert 'request' in kwargs
+        assert 'exception' in kwargs
+
+        http_data = kwargs['request']
+        self.assertEqual(http_data['cookies'], None)
+        self.assertEqual(http_data['url'], response.effective_url)
+        self.assertEqual(http_data['query_string'], 'code=500')
+        self.assertEqual(http_data['method'], 'GET')
+
+        user_data = kwargs['user']
+        self.assertEqual(user_data['is_authenticated'], False)
+
+    @patch('raven.contrib.tornado.AsyncSentryClient.send')
+    def test_http_error_400(self, send):
+        response = self.fetch('/http-error?code=400')
+        self.assertEqual(response.code, 400)
+        self.assertEqual(send.call_count, 0)


### PR DESCRIPTION
Fixes #715