### PR TITLE
Fix disabling of ssl certs check with python 2.7.9/3.4.3 and sync/threaded transport

### DIFF
--- a/raven/utils/http.py
+++ b/raven/utils/http.py
@@ -48,7 +48,11 @@ def urlopen(url, data=None, timeout=defaults.TIMEOUT, ca_certs=None,
     if verify_ssl:
         handlers = [ValidHTTPSHandler]
     else:
-        handlers = []
+        try:
+            handlers = [urllib2.HTTPSHandler(
+                context=ssl._create_unverified_context())]
+        except AttributeError:
+            handlers = []
 
     opener = urllib2.build_opener(*handlers)
 


### PR DESCRIPTION
Since PEP 467  python perform certificate validation by default http://stackoverflow.com/a/28325763.
So there is an issue with python 2.7.9/3.4.3 and the disabling of the certificate check with "?ssl_verify=0" and the sync/threaded transport.
I think it's link to this issue #683.