### PR TITLE
remove unneeded shebang

### DIFF
--- a/raven/contrib/zope/__init__.py
+++ b/raven/contrib/zope/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
 raven.contrib.zope


### PR DESCRIPTION
The shebang triggers an error in the Fedora Package (E: non-executable-script)