### PR TITLE
Allow logging exclusions during object creation and `init_app`

### DIFF
--- a/docs/integrations/flask.rst
+++ b/docs/integrations/flask.rst
@@ -30,7 +30,8 @@ You can optionally configure logging too::
 
     import logging
     from raven.contrib.flask import Sentry
-    sentry = Sentry(app, logging=True, level=logging.ERROR)
+    sentry = Sentry(app, logging=True, level=logging.ERROR, \
+                    logging_exclusions=("logger1", "logger2", ...))
 
 Building applications on the fly? You can use Raven's ``init_app`` hook::
 
@@ -48,7 +49,8 @@ You can pass parameters in the ``init_app`` hook::
     def create_app():
         app = Flask(__name__)
         sentry.init_app(app, dsn='___DSN___', logging=True,
-                        level=logging.ERROR)
+                        level=logging.ERROR,
+                        logging_exclusions=("logger1", "logger2", ...))
         return app
 
 Settings

--- a/docs/integrations/logging.rst
+++ b/docs/integrations/logging.rst
@@ -132,3 +132,13 @@ message within Sentry::
     logger.error('There was some %s error', 'crazy')
     logger.error('There was some %s error', 'fun')
     logger.error('There was some %s error', 1)
+
+Exclusions
+~~~~~~~~~~
+
+You can also configure some logging exclusions during setup. These loggers
+will not propagate their logs to the Sentry handler.
+
+    from raven.conf import setup_logging
+
+    setup_logging(handler, exclude=("logger1", "logger2", ...))

--- a/tests/contrib/flask/tests.py
+++ b/tests/contrib/flask/tests.py
@@ -263,6 +263,19 @@ class FlaskTest(BaseTest):
             assert self.middleware.last_event_id == event_id
             assert g.sentry_event_id == event_id
 
+    def test_logging_setup_with_exclusion_list(self):
+        app = Flask(__name__)
+        raven = TempStoreClient()
+
+        Sentry(app, client=raven, logging=True,
+            logging_exclusions=("excluded_logger",))
+
+        excluded_logger = logging.getLogger("excluded_logger")
+        self.assertFalse(excluded_logger.propagate)
+
+        some_other_logger = logging.getLogger("some_other_logger")
+        self.assertTrue(some_other_logger.propagate)
+
 
 class FlaskLoginTest(BaseTest):
 


### PR DESCRIPTION
Hi there! 

This PR would allow the passage of a logging exclusions to the logging setup during the creation of the `Sentry` object or while calling `init_app`. Something like:

```python
sentry_object = Sentry(..., logging=True, logging_exclusions=("logger1", "logger2", ...))
```

This in turn would call the `setup_logging` like so:

```python
setup_logging(SentryHandler(self.client, level=self.level), exclude=the_passed_tuple)
```

Would you folks be open to something like this? If so, then i could go ahead and write some tests or clean this up a little bit.