### PR TITLE
Remove unnecessary/confusing variable from Celery contrib

### DIFF
--- a/raven/contrib/celery/__init__.py
+++ b/raven/contrib/celery/__init__.py
@@ -7,6 +7,8 @@ raven.contrib.celery
 """
 from __future__ import absolute_import
 
+import logging
+
 from celery.signals import after_setup_logger, task_failure
 from raven.handlers.logging import SentryHandler
 


### PR DESCRIPTION
This `logger` variable is, as far I can tell, ineffectual and also confusing.

I didn't remove the kwarg from the function definition because I figure we should maintain API compatibility (despite the fact that this arg doesn't seem to do anything). Maybe we should add a deprecation warning in prep for removal?

Thanks for the great product.