### PR TITLE
Fix documentation for the gevent transport

### DIFF
--- a/docs/transports.rst
+++ b/docs/transports.rst
@@ -51,9 +51,9 @@ Should only be used within a Gevent IO loop.
 
 .. code-block:: python
 
-    from raven.transport.gevent import GeventHTTPTransport
+    from raven.transport.gevent import GeventedHTTPTransport
 
-    Client('...', transport=GeventHTTPTransport)
+    Client('...', transport=GeventedHTTPTransport)
 
 
 Requests


### PR DESCRIPTION
The gevent transport is called GeventHTTPTransport in the docs but its real name is GeventedHTTPTransport