### PR TITLE
Dont implicitly configure log handlers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Version 5.11.0
+--------------
+
+* ``Client.configure_logging`` has been removed, and handlers will not automatically
+  be added to 'sentry' and 'raven' namespaces.
+
 Version 5.10.3
 --------------
 

--- a/raven/base.py
+++ b/raven/base.py
@@ -133,8 +133,6 @@ class Client(object):
 
         o = options
 
-        self.configure_logging()
-
         self.raise_send_errors = raise_send_errors
 
         # configure loggers first
@@ -224,14 +222,6 @@ class Client(object):
     @classmethod
     def register_scheme(cls, scheme, transport_class):
         cls._registry.register_scheme(scheme, transport_class)
-
-    def configure_logging(self):
-        for name in ('raven', 'sentry'):
-            logger = logging.getLogger(name)
-            if logger.handlers:
-                continue
-            logger.addHandler(logging.StreamHandler())
-            logger.setLevel(logging.INFO)
 
     def get_processors(self):
         for processor in self.processors:

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ class PyTest(TestCommand):
 
 setup(
     name='raven',
-    version='5.10.3.dev.0',
+    version='5.11.0.dev.0',
     author='Sentry',
     author_email='hello@getsentry.com',
     url='https://github.com/getsentry/raven-python',


### PR DESCRIPTION
Because of the way logging propagation works this is complicated to ensure it's intelligent. Let's leave it up to the user to ensure LOGGING is configured appropriately for their application.