### PR TITLE
Check for falsy dsn and not None dsn

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -187,13 +187,13 @@ class Client(object):
             self.install_sys_hook()
 
     def set_dsn(self, dsn=None, transport=None):
-        if dsn is None and os.environ.get('SENTRY_DSN'):
+        if not dsn and os.environ.get('SENTRY_DSN'):
             msg = "Configuring Raven from environment variable 'SENTRY_DSN'"
             self.logger.debug(msg)
             dsn = os.environ['SENTRY_DSN']
 
         if dsn not in self._transport_cache:
-            if dsn is None:
+            if not dsn:
                 result = RemoteConfig(transport=transport)
             else:
                 result = RemoteConfig.from_string(

--- a/tests/base/tests.py
+++ b/tests/base/tests.py
@@ -6,6 +6,7 @@ import mock
 import raven
 import time
 import six
+import os
 
 from raven.base import Client, ClientState
 from raven.exceptions import RateLimited
@@ -93,6 +94,15 @@ class ClientTest(TestCase):
 
         assert base.Raven is client
         assert client is not client2
+
+    def test_client_picks_up_env_dsn(self):
+        DSN = 'sync+http://public:secret@example.com/1'
+        PUBLIC_DSN = '//public@example.com/1'
+        with mock.patch.dict(os.environ, {'SENTRY_DSN': DSN}):
+            client = Client()
+            assert client.remote.get_public_dsn() == PUBLIC_DSN
+            client = Client('')
+            assert client.remote.get_public_dsn() == PUBLIC_DSN
 
     @mock.patch('raven.transport.http.HTTPTransport.send')
     @mock.patch('raven.base.ClientState.should_try')


### PR DESCRIPTION
This only sets the DSN if it's not falsy. This means you can now pass the empty string to pick up the default instead of having to set it to `None`.