### PR TITLE
Be more explicit that Django logging integration only captures ERROR

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -78,8 +78,8 @@ override:
 Integration with :mod:`logging`
 -------------------------------
 
-To integrate with the standard library's :mod:`logging` module the
-following config can be used::
+To integrate with the standard library's :mod:`logging` module, and send all
+ERROR and above messages to sentry, the following config can be used::
 
     LOGGING = {
         'version': 1,
@@ -96,7 +96,7 @@ following config can be used::
         },
         'handlers': {
             'sentry': {
-                'level': 'ERROR',
+                'level': 'ERROR', # To capture more than ERROR, change to WARNING, INFO, etc.
                 'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
                 'tags': {'custom-tag': 'x'},
             },


### PR DESCRIPTION
The django LOGGING integration docs don't mention that they only capture ERROR and a user was having trouble in IRC (https://botbot.me/freenode/sentry/2016-04-12/?msg=63974495&page=1) as a result.

It's a fine line between documenting all the minutiae of how this works and sending people to the Python logging docs, but I imagine the most common modification people would want is to send WARNING or INFO to Sentry.