### PR TITLE
Make sure tornado implementations have access to future

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -682,7 +682,7 @@ class Client(object):
             'Content-Type': 'application/octet-stream',
         }
 
-        self.send_remote(
+        return self.send_remote(
             url=self.remote.store_endpoint,
             data=message,
             headers=headers,

--- a/raven/contrib/tornado/__init__.py
+++ b/raven/contrib/tornado/__init__.py
@@ -38,9 +38,9 @@ class AsyncSentryClient(Client):
 
         data = self.build_msg(*args, **kwargs)
 
-        self.send(callback=kwargs.get('callback', None), **data)
+        future = self.send(callback=kwargs.get('callback', None), **data)
 
-        return (data['event_id'],)
+        return (data['event_id'], future)
 
     def send(self, auth_header=None, callback=None, **data):
         """


### PR DESCRIPTION
send_encoded not returning seems to be a simple mistake - only use returns its value and django impl returns a value.

Returning a future in AsyncSentryClient makes sense for times when you want to make sure the error got sent to Sentry or you would like to keep it somewhere so you can wait for it later (for testing purposes).