### PR TITLE
Catch all exceptions raised from setuptools

### DIFF
--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -65,7 +65,7 @@ def get_version_from_app(module_name, app):
         # pull version from pkg_resources if distro exists
         try:
             return pkg_resources.get_distribution(module_name).version
-        except pkg_resources.DistributionNotFound:
+        except Exception:
             pass
 
     if hasattr(app, 'get_version'):


### PR DESCRIPTION
Newer versions of setuptools have changed the API to be more restrictive
and whatnot, and now spits different errors.

Instead of whitelisting specific errors, just catch them all so we never
have to worry about it again.

This also had to be done in Sentry: https://github.com/getsentry/sentry/commit/d32b14020ec37b7e895f443409dd004afa67f298
@mitsuhiko 