### PR TITLE
record_breadcrumb requires type as first arg

### DIFF
--- a/docs/breadcrumbs.rst
+++ b/docs/breadcrumbs.rst
@@ -88,7 +88,7 @@ Example:
 
     from raven.breadcrumbs import record_breadcrumb
 
-    record_breadcrumb(message='This is an important message',
+    record_breadcrumb('info', message='This is an important message',
                       category='my_module', level='warning')
 
 Because crumbs go into a ring buffer, often it can be useful to defer
@@ -103,7 +103,7 @@ modifications:
     def process_crumb(data):
         data['data'] = compute_expensive_data()
 
-    record_breadcrumb(message='This is an important message',
+    record_breadcrumb('info', message='This is an important message',
                       category='my_module', level='warning',
                       processor=process_crumb)
 

--- a/docs/breadcrumbs.rst
+++ b/docs/breadcrumbs.rst
@@ -88,7 +88,7 @@ Example:
 
     from raven.breadcrumbs import record_breadcrumb
 
-    record_breadcrumb('info', message='This is an important message',
+    record_breadcrumb('default', message='This is an important message',
                       category='my_module', level='warning')
 
 Because crumbs go into a ring buffer, often it can be useful to defer
@@ -103,7 +103,7 @@ modifications:
     def process_crumb(data):
         data['data'] = compute_expensive_data()
 
-    record_breadcrumb('info', message='This is an important message',
+    record_breadcrumb('default', message='This is an important message',
                       category='my_module', level='warning',
                       processor=process_crumb)
 


### PR DESCRIPTION
See [the code](https://github.com/getsentry/raven-python/blob/76b29f1d41ff2e251f6630243a3a833651268463/raven/breadcrumbs.py#L59)