### PR TITLE
Use built-in contextlib on python 2.7

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -20,10 +20,10 @@ from datetime import datetime
 from pprint import pformat
 from types import FunctionType
 
-if sys.version_info >= (3, 2):
-    import contextlib
-else:
+try:
     import contextlib2 as contextlib
+except ImportError:
+    import contextlib
 
 try:
     from thread import get_ident as get_thread_ident
@@ -800,7 +800,6 @@ class Client(object):
         elif function_or_exceptions is not None:
             exceptions = function_or_exceptions
 
-        # In python3.2 contextmanager acts both as contextmanager and decorator
         @contextlib.contextmanager
         def make_decorator(exceptions):
             try:

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ if sys.version_info[0] == 3:
     # If it's python3.2 or greater, don't use contextlib backport
     if sys.version_info[1] >= 2:
         install_requires.remove('contextlib2')
+elif sys.version_info[0] == 2 and sys.version_info[1] == 7:
+    # If we're on python 2.7, don't use contextlib backport
+    install_requires.remove('contextlib2')
 
 tests_require = [
     'six',


### PR DESCRIPTION
We don't need to use the contextlib2 backport on python 2.7