### PR TITLE
Replace culprits with transaction names

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -81,4 +81,5 @@ def pytest_configure(config):
                 ],
             }],
             ALLOWED_HOSTS=['*'],
+            DISABLE_SENTRY_INSTRUMENTATION=True,
         )

--- a/raven/base.py
+++ b/raven/base.py
@@ -37,7 +37,7 @@ from raven.utils import json, get_versions, get_auth_header, merge_dicts
 from raven._compat import text_type, iteritems
 from raven.utils.encoding import to_unicode
 from raven.utils.serializer import transform
-from raven.utils.stacks import get_stack_info, iter_stack_frames
+from raven.utils.stacks import get_stack_info, iter_stack_frames, slim_string
 from raven.utils.transaction import TransactionStack
 from raven.transport.registry import TransportRegistry, default_transports
 
@@ -188,6 +188,9 @@ class Client(object):
         self.environment = o.get('environment') or None
         self.release = o.get('release') or os.environ.get('HEROKU_SLUG_COMMIT')
         self.transaction = TransactionStack()
+        # find the root transaction as the command which launched this
+        # process
+        self.transaction.push(slim_string(' '.join(sys.argv), 128))
 
         self.ignore_exceptions = set(o.get('ignore_exceptions') or ())
 

--- a/raven/contrib/django/middleware/__init__.py
+++ b/raven/contrib/django/middleware/__init__.py
@@ -88,7 +88,6 @@ class SentryMiddleware(threading.local):
                 self._get_transaction_from_request(request)
             )
         except Exception as exc:
-            raise
             client.error_logger.exception(repr(exc))
         return None
 

--- a/raven/contrib/django/middleware/__init__.py
+++ b/raven/contrib/django/middleware/__init__.py
@@ -94,7 +94,11 @@ class SentryMiddleware(threading.local):
             # we utilize request_finished as the exception gets reported
             # *after* process_response is executed, and thus clearing the
             # transaction there would leave it empty
-            request_finished.connect(self.request_finished)
+            # XXX(dcramer): weakref's cause a threading issue in certain
+            # versions of Django (e.g. 1.6). While they'd be ideal, we're under
+            # the assumption that Django will always call our function except
+            # in the situation of a process or thread dying.
+            request_finished.connect(self.request_finished, weak=False)
 
         return None
 

--- a/raven/contrib/django/resolver.py
+++ b/raven/contrib/django/resolver.py
@@ -29,7 +29,10 @@ class RouteResolver(object):
         > "{sport_slug}/athletes/{athlete_slug}/"
         """
         # remove optional params
-        pattern = self._optional_group_matcher.sub(lambda m: '[%s]' % m.group(1), pattern)
+        # TODO(dcramer): it'd be nice to change these into [%s] but it currently
+        # conflicts with the other rules because we're doing regexp matches
+        # rather than parsing tokens
+        pattern = self._optional_group_matcher.sub(lambda m: '%s' % m.group(1), pattern)
 
         # handle named groups first
         pattern = self._named_group_matcher.sub(lambda m: '{%s}' % m.group(1), pattern)

--- a/raven/contrib/django/resolver.py
+++ b/raven/contrib/django/resolver.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 
 import re
 
-from django.urls import get_resolver, Resolver404
+try:
+    from django.urls import get_resolver, Resolver404
+except ImportError:
+    from django.core.urlresolvers import get_resolver, Resolver404
 
 
 class RouteResolver(object):

--- a/raven/contrib/django/resolver.py
+++ b/raven/contrib/django/resolver.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import
 import re
 
 try:
-    from django.urls import get_resolver, Resolver404
+    from django.urls import get_resolver
 except ImportError:
-    from django.core.urlresolvers import get_resolver, Resolver404
+    from django.core.urlresolvers import get_resolver
 
 
 class RouteResolver(object):
@@ -32,44 +32,58 @@ class RouteResolver(object):
         # TODO(dcramer): it'd be nice to change these into [%s] but it currently
         # conflicts with the other rules because we're doing regexp matches
         # rather than parsing tokens
-        pattern = self._optional_group_matcher.sub(lambda m: '%s' % m.group(1), pattern)
+        result = self._optional_group_matcher.sub(lambda m: '%s' % m.group(1), pattern)
 
         # handle named groups first
-        pattern = self._named_group_matcher.sub(lambda m: '{%s}' % m.group(1), pattern)
+        result = self._named_group_matcher.sub(lambda m: '{%s}' % m.group(1), result)
 
         # handle non-named groups
-        pattern = self._non_named_group_matcher.sub("{var}", pattern)
+        result = self._non_named_group_matcher.sub('{var}', result)
 
         # handle optional params
-        pattern = self._either_option_matcher.sub(lambda m: m.group(1), pattern)
+        result = self._either_option_matcher.sub(lambda m: m.group(1), result)
 
         # clean up any outstanding regex-y characters.
-        pattern = pattern.replace('^', '').replace('$', '') \
+        result = result.replace('^', '').replace('$', '') \
             .replace('?', '').replace('//', '/').replace('\\', '')
-        if not pattern.startswith('/'):
-            pattern = '/' + pattern
-        return pattern
+
+        return result
+
+    def _resolve(self, resolver, path, parents=None):
+        match = resolver.regex.search(path)
+        if not match:
+            return
+
+        if parents is None:
+            parents = [resolver]
+        else:
+            parents.append(resolver)
+
+        new_path = path[match.end():]
+        for pattern in resolver.url_patterns:
+            # this is an include()
+            if not pattern.callback:
+                match = self._resolve(pattern, new_path, parents)
+                if match:
+                    return match
+                continue
+
+            elif not pattern.regex.search(new_path):
+                continue
+
+            try:
+                return self._cache[pattern]
+            except KeyError:
+                pass
+
+            prefix = ''.join(self._simplify(p.regex.pattern) for p in parents)
+            result = prefix + self._simplify(pattern.regex.pattern)
+            if not result.startswith('/'):
+                result = '/' + result
+            self._cache[pattern] = result
+            return result
 
     def resolve(self, path, urlconf=None):
-        # TODO(dcramer): it'd be nice to pull out parameters
-        # and make this a normalized path
         resolver = get_resolver(urlconf)
-        match = resolver.regex.search(path)
-        if match:
-            new_path = path[match.end():]
-            for pattern in resolver.url_patterns:
-                try:
-                    sub_match = pattern.resolve(new_path)
-                except Resolver404:
-                    continue
-                if sub_match:
-                    pattern = pattern.regex.pattern
-                    try:
-                        return self._cache[pattern]
-                    except KeyError:
-                        pass
-
-                    pattern_name = self._simplify(pattern)
-                    self._cache[pattern] = pattern
-                    return pattern_name
-        return path
+        match = self._resolve(resolver, path)
+        return match or path

--- a/raven/contrib/django/resolver.py
+++ b/raven/contrib/django/resolver.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import
+
+import re
+
+from django.urls import get_resolver, Resolver404
+
+
+class RouteResolver(object):
+    _optional_group_matcher = re.compile(r'\(\?\:([^\)]+)\)')
+    _named_group_matcher = re.compile(r'\(\?P<(\w+)>[^\)]+\)')
+    _non_named_group_matcher = re.compile(r'\([^\)]+\)')
+    # [foo|bar|baz]
+    _either_option_matcher = re.compile(r'\[([^\]]+)\|([^\]]+)\]')
+    _camel_re = re.compile(r'([A-Z]+)([a-z])')
+
+    _cache = {}
+
+    def _simplify(self, pattern):
+        """
+        Clean up urlpattern regexes into something readable by humans:
+
+        From:
+        > "^(?P<sport_slug>\w+)/athletes/(?P<athlete_slug>\w+)/$"
+
+        To:
+        > "{sport_slug}/athletes/{athlete_slug}/"
+        """
+        # remove optional params
+        pattern = self._optional_group_matcher.sub(lambda m: '[%s]' % m.group(1), pattern)
+
+        # handle named groups first
+        pattern = self._named_group_matcher.sub(lambda m: '{%s}' % m.group(1), pattern)
+
+        # handle non-named groups
+        pattern = self._non_named_group_matcher.sub("{var}", pattern)
+
+        # handle optional params
+        pattern = self._either_option_matcher.sub(lambda m: m.group(1), pattern)
+
+        # clean up any outstanding regex-y characters.
+        pattern = pattern.replace('^', '').replace('$', '') \
+            .replace('?', '').replace('//', '/').replace('\\', '')
+        if not pattern.startswith('/'):
+            pattern = '/' + pattern
+        return pattern
+
+    def resolve(self, path, urlconf=None):
+        # TODO(dcramer): it'd be nice to pull out parameters
+        # and make this a normalized path
+        resolver = get_resolver(urlconf)
+        match = resolver.regex.search(path)
+        if match:
+            new_path = path[match.end():]
+            for pattern in resolver.url_patterns:
+                try:
+                    sub_match = pattern.resolve(new_path)
+                except Resolver404:
+                    continue
+                if sub_match:
+                    pattern = pattern.regex.pattern
+                    try:
+                        return self._cache[pattern]
+                    except KeyError:
+                        pass
+
+                    pattern_name = self._simplify(pattern)
+                    self._cache[pattern] = pattern
+                    return pattern_name
+        return path

--- a/raven/contrib/django/urls.py
+++ b/raven/contrib/django/urls.py
@@ -16,6 +16,6 @@ except ImportError:
 import raven.contrib.django.views
 
 urlpatterns = (
-    url(r'^api/(?:(?P<project_id>[\w_-]+)/)?store/$', raven.contrib.django.views.report, name='raven-report'),
+    url(r'^api/(?P<project_id>[\w_-]+)/store/$', raven.contrib.django.views.report, name='raven-report'),
     url(r'^report/', raven.contrib.django.views.report),
 )

--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -216,6 +216,9 @@ class Sentry(object):
 
     def before_request(self, *args, **kwargs):
         self.last_event_id = None
+
+        self.client.transaction.push(request.url_rule.rule)
+
         try:
             self.client.http_context(self.get_http_info(request))
         except Exception as e:
@@ -229,6 +232,7 @@ class Sentry(object):
         if self.last_event_id:
             response.headers['X-Sentry-ID'] = self.last_event_id
         self.client.context.clear()
+        self.client.transaction.pop(request.url_rule.rule)
         return response
 
     def init_app(self, app, dsn=None, logging=None, level=None,

--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -17,7 +17,7 @@ import traceback
 from raven._compat import string_types, iteritems, text_type
 from raven.base import Client
 from raven.utils.encoding import to_string
-from raven.utils.stacks import iter_stack_frames, label_from_frame
+from raven.utils.stacks import iter_stack_frames
 
 RESERVED = frozenset((
     'stack', 'name', 'module', 'funcName', 'args', 'msg', 'levelno',
@@ -158,16 +158,6 @@ class SentryHandler(logging.Handler, object):
 
             event_type = 'raven.events.Exception'
             handler_kwargs = {'exc_info': record.exc_info}
-
-        # HACK: discover a culprit when we normally couldn't
-        elif not (data.get('stacktrace') or data.get('culprit')) \
-                and (record.name or record.funcName):
-            culprit = label_from_frame({
-                'module': record.name,
-                'function': record.funcName
-            })
-            if culprit:
-                data['culprit'] = culprit
 
         data['level'] = record.levelno
         data['logger'] = record.name

--- a/raven/middleware.py
+++ b/raven/middleware.py
@@ -70,6 +70,7 @@ class ClosingIterator(Iterator):
                     self.iterable.close()
         finally:
             self.sentry.client.context.clear()
+            self.sentry.transaction.clear()
             self.closed = True
 
 

--- a/raven/middleware.py
+++ b/raven/middleware.py
@@ -70,7 +70,7 @@ class ClosingIterator(Iterator):
                     self.iterable.close()
         finally:
             self.sentry.client.context.clear()
-            self.sentry.transaction.clear()
+            self.sentry.client.transaction.clear()
             self.closed = True
 
 

--- a/raven/utils/stacks.py
+++ b/raven/utils/stacks.py
@@ -11,7 +11,6 @@ import inspect
 import linecache
 import re
 import sys
-import warnings
 
 from raven.utils.serializer import transform
 from raven._compat import iteritems
@@ -80,41 +79,6 @@ def get_lines_from_file(filename, lineno, context_lines,
         slim_string(context_line),
         slim_string(post_context)
     )
-
-
-def label_from_frame(frame):
-    module = frame.get('module') or '?'
-    function = frame.get('function') or '?'
-    if module == function == '?':
-        return ''
-    return '%s in %s' % (module, function)
-
-
-def get_culprit(frames, *args, **kwargs):
-    # We iterate through each frame looking for a deterministic culprit
-    # When one is found, we mark it as last "best guess" (best_guess) and then
-    # check it against ``exclude_paths``. If it isn't listed, then we
-    # use this option. If nothing is found, we use the "best guess".
-    if args or kwargs:
-        warnings.warn('get_culprit no longer does application detection')
-
-    best_guess = None
-    culprit = None
-    for frame in reversed(frames):
-        culprit = label_from_frame(frame)
-        if not culprit:
-            culprit = None
-            continue
-
-        if frame.get('in_app'):
-            return culprit
-        elif not best_guess:
-            best_guess = culprit
-        elif best_guess:
-            break
-
-    # Return either the best guess or the last frames call
-    return best_guess or culprit
 
 
 def _getitem_from_frame(f_locals, key, default=None):

--- a/raven/utils/testutils.py
+++ b/raven/utils/testutils.py
@@ -7,6 +7,8 @@ raven.utils.testutils
 """
 from __future__ import absolute_import
 
+import raven
+
 from exam import Exam
 
 try:
@@ -17,3 +19,15 @@ except ImportError:
 
 class TestCase(Exam, BaseTestCase):
     pass
+
+
+class InMemoryClient(raven.Client):
+    def __init__(self, **kwargs):
+        self.events = []
+        super(InMemoryClient, self).__init__(**kwargs)
+
+    def is_enabled(self):
+        return True
+
+    def send(self, **kwargs):
+        self.events.append(kwargs)

--- a/raven/utils/transaction.py
+++ b/raven/utils/transaction.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+
+from threading import local
+
+
+class TransactionContext(object):
+    def __init__(self, stack, context):
+        self.stack = stack
+        self.context = context
+
+    def __enter__(self):
+        self.stack.push(self.context)
+        return self
+
+    def __exit__(self, *exc_info):
+        self.stack.pop(self.context)
+
+
+class TransactionStack(local):
+    def __init__(self):
+        self.stack = []
+
+    def __len__(self):
+        return len(self.stack)
+
+    def __iter__(self):
+        return iter(self.stack)
+
+    def __call__(self, context):
+        return TransactionContext(self, context)
+
+    def clear(self):
+        self.stack = []
+
+    def peek(self):
+        try:
+            return self.stack[-1]
+        except IndexError:
+            return None
+
+    def push(self, context):
+        self.stack.append(context)
+        return context
+
+    def pop(self, context=None):
+        if context is None:
+            return self.stack.pop()
+
+        while self.stack:
+            if self.stack.pop() is context:
+                return context

--- a/tests/contrib/django/test_resolver.py
+++ b/tests/contrib/django/test_resolver.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+
+from raven.contrib.django.resolver import RouteResolver
+
+
+def test_no_match():
+    resolver = RouteResolver()
+    result = resolver.resolve('/foo/bar', 'raven.contrib.django.urls')
+    assert result == '/foo/bar'
+
+
+def test_simple_match():
+    resolver = RouteResolver()
+    result = resolver.resolve('/report/', 'raven.contrib.django.urls')
+    assert result == '/report/'
+
+
+def test_complex_match():
+    resolver = RouteResolver()
+    result = resolver.resolve('/api/1234/store/', 'raven.contrib.django.urls')
+    assert result == '/api/{project_id}/store/'

--- a/tests/contrib/django/test_resolver.py
+++ b/tests/contrib/django/test_resolver.py
@@ -1,21 +1,42 @@
 from __future__ import absolute_import
 
+try:
+    from django.conf.urls import url, include
+except ImportError:
+    # for Django version less than 1.4
+    from django.conf.urls.defaults import url, include  # NOQA
+
 from raven.contrib.django.resolver import RouteResolver
+
+included_url_conf = (
+    url(r'^foo/bar/(?P<param>[\w]+)', lambda x: ''),
+), '', ''
+
+example_url_conf = (
+    url(r'^api/(?P<project_id>[\w_-]+)/store/$', lambda x: ''),
+    url(r'^example/', include(included_url_conf)),
+)
 
 
 def test_no_match():
     resolver = RouteResolver()
-    result = resolver.resolve('/foo/bar', 'raven.contrib.django.urls')
+    result = resolver.resolve('/foo/bar', example_url_conf)
     assert result == '/foo/bar'
 
 
 def test_simple_match():
     resolver = RouteResolver()
-    result = resolver.resolve('/report/', 'raven.contrib.django.urls')
+    result = resolver.resolve('/report/', example_url_conf)
     assert result == '/report/'
 
 
 def test_complex_match():
     resolver = RouteResolver()
-    result = resolver.resolve('/api/1234/store/', 'raven.contrib.django.urls')
+    result = resolver.resolve('/api/1234/store/', example_url_conf)
     assert result == '/api/{project_id}/store/'
+
+
+def test_included_match():
+    resolver = RouteResolver()
+    result = resolver.resolve('/example/foo/bar/baz', example_url_conf)
+    assert result == '/example/foo/bar/{param}'

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -28,7 +28,9 @@ from raven.base import Client
 from raven.contrib.django.client import DjangoClient
 from raven.contrib.django.celery import CeleryClient
 from raven.contrib.django.handlers import SentryHandler
-from raven.contrib.django.models import client, get_client, sentry_exception_handler
+from raven.contrib.django.models import (
+    SentryDjangoHandler, client, get_client
+)
 from raven.contrib.django.middleware.wsgi import Sentry
 from raven.contrib.django.templatetags.raven import sentry_public_dsn
 from raven.contrib.django.views import is_valid_origin
@@ -36,6 +38,7 @@ from raven.transport import HTTPTransport
 from raven.utils.serializer import transform
 
 from django.test.client import Client as TestClient, ClientHandler as TestClientHandler
+
 from .models import TestModel
 
 settings.SENTRY_CLIENT = 'tests.contrib.django.tests.TempStoreClient'
@@ -128,6 +131,9 @@ class DjangoClientTest(TestCase):
 
     def setUp(self):
         self.raven = get_client()
+        self.handler = SentryDjangoHandler(self.raven)
+        self.handler.install()
+        self.addCleanup(self.handler.uninstall)
 
     def test_basic(self):
         self.raven.captureMessage(message='foo')
@@ -156,7 +162,6 @@ class DjangoClientTest(TestCase):
         assert exc['value'], "int() argument must be a string or a number == not 'NoneType'"
         assert event['level'] == logging.ERROR
         assert event['message'], "TypeError: int() argument must be a string or a number == not 'NoneType'"
-        assert event['culprit'] == 'tests.contrib.django.tests in test_signal_integration'
 
     @pytest.mark.skipif(sys.version_info[:2] == (2, 6), reason='Python 2.6')
     def test_view_exception(self):
@@ -170,7 +175,6 @@ class DjangoClientTest(TestCase):
         assert exc['value'] == 'view exception'
         assert event['level'] == logging.ERROR
         assert event['message'] == 'Exception: view exception'
-        assert event['culprit'] == 'tests.contrib.django.views in raise_exc'
 
     def test_user_info(self):
         with Settings(MIDDLEWARE_CLASSES=[
@@ -262,7 +266,6 @@ class DjangoClientTest(TestCase):
             assert exc['value'] == 'request'
             assert event['level'] == logging.ERROR
             assert event['message'] == 'ImportError: request'
-            assert event['culprit'] == 'tests.contrib.django.middleware in process_request'
 
     def test_response_middlware_exception(self):
         if django.VERSION[:2] < (1, 3):
@@ -279,7 +282,6 @@ class DjangoClientTest(TestCase):
             assert exc['value'] == 'response'
             assert event['level'] == logging.ERROR
             assert event['message'] == 'ImportError: response'
-            assert event['culprit'] == 'tests.contrib.django.middleware in process_response'
 
     def test_broken_500_handler_with_middleware(self):
         with Settings(BREAK_THAT_500=True, INSTALLED_APPS=['raven.contrib.django']):
@@ -297,7 +299,6 @@ class DjangoClientTest(TestCase):
             assert exc['value'] == 'view exception'
             assert event['level'] == logging.ERROR
             assert event['message'] == 'Exception: view exception'
-            assert event['culprit'] == 'tests.contrib.django.views in raise_exc'
 
             event = self.raven.events.pop(0)
 
@@ -307,7 +308,6 @@ class DjangoClientTest(TestCase):
             assert exc['value'] == 'handler500'
             assert event['level'] == logging.ERROR
             assert event['message'] == 'ValueError: handler500'
-            assert event['culprit'] == 'tests.contrib.django.urls in handler500'
 
     def test_view_middleware_exception(self):
         with Settings(MIDDLEWARE_CLASSES=['tests.contrib.django.middleware.BrokenViewMiddleware']):
@@ -322,30 +322,6 @@ class DjangoClientTest(TestCase):
             assert exc['value'] == 'view'
             assert event['level'] == logging.ERROR
             assert event['message'] == 'ImportError: view'
-            assert event['culprit'] == 'tests.contrib.django.middleware in process_view'
-
-    def test_exclude_modules_view(self):
-        exclude_paths = self.raven.exclude_paths
-        self.raven.exclude_paths = ['tests.views']
-        self.assertRaises(Exception, self.client.get, reverse('sentry-raise-exc-decor'))
-
-        assert len(self.raven.events) == 1
-        event = self.raven.events.pop(0)
-
-        assert event['culprit'] == 'tests.contrib.django.views in raise_exc'
-        self.raven.exclude_paths = exclude_paths
-
-    def test_include_modules(self):
-        include_paths = self.raven.include_paths
-        self.raven.include_paths = ['django.shortcuts']
-
-        self.assertRaises(Exception, self.client.get, reverse('sentry-django-exc'))
-
-        assert len(self.raven.events) == 1
-        event = self.raven.events.pop(0)
-
-        assert event['culprit'].startswith('django.shortcuts in ')
-        self.raven.include_paths = include_paths
 
     @pytest.mark.skipif(DJANGO_18, reason='Django 1.8+ not supported')
     def test_template_name_as_view(self):
@@ -393,7 +369,7 @@ class DjangoClientTest(TestCase):
             resp = self.client.get('/non-existent-page')
             assert resp.status_code == 404
 
-            assert len(self.raven.events) == 1
+            assert len(self.raven.events) == 1, [e['message'] for e in self.raven.events]
             event = self.raven.events.pop(0)
 
             assert event['level'] == logging.INFO
@@ -786,11 +762,16 @@ class SentryExceptionHandlerTest(TestCase):
     def exc_info(self):
         return (ValueError, ValueError('lol world'), None)
 
+    def setUp(self):
+        super(SentryExceptionHandlerTest, self).setUp()
+        self.client = get_client()
+        self.handler = SentryDjangoHandler(self.client)
+
     @mock.patch.object(TempStoreClient, 'captureException')
     @mock.patch('sys.exc_info')
     def test_does_capture_exception(self, exc_info, captureException):
         exc_info.return_value = self.exc_info
-        sentry_exception_handler(request=self.request)
+        self.handler.exception_handler(request=self.request)
 
         captureException.assert_called_once_with(exc_info=self.exc_info, request=self.request)
 
@@ -799,11 +780,11 @@ class SentryExceptionHandlerTest(TestCase):
     def test_does_exclude_filtered_types(self, exc_info, mock_send):
         exc_info.return_value = self.exc_info
         try:
-            get_client().ignore_exceptions = set(['ValueError'])
+            self.client.ignore_exceptions = set(['ValueError'])
 
-            sentry_exception_handler(request=self.request)
+            self.handler.exception_handler(request=self.request)
         finally:
-            get_client().ignore_exceptions.clear()
+            self.client.ignore_exceptions.clear()
 
         assert not mock_send.called
 
@@ -814,12 +795,12 @@ class SentryExceptionHandlerTest(TestCase):
 
         try:
             if six.PY3:
-                get_client().ignore_exceptions = set(['builtins.*'])
+                self.client.ignore_exceptions = set(['builtins.*'])
             else:
-                get_client().ignore_exceptions = set(['exceptions.*'])
-            sentry_exception_handler(request=self.request)
+                self.client.ignore_exceptions = set(['exceptions.*'])
+            self.handler.exception_handler(request=self.request)
         finally:
-            get_client().ignore_exceptions.clear()
+            self.client.ignore_exceptions.clear()
 
         assert not mock_send.called
 
@@ -830,11 +811,11 @@ class SentryExceptionHandlerTest(TestCase):
 
         try:
             if six.PY3:
-                get_client().ignore_exceptions = set(['builtins.ValueError'])
+                self.client.ignore_exceptions = set(['builtins.ValueError'])
             else:
-                get_client().ignore_exceptions = set(['exceptions.ValueError'])
-            sentry_exception_handler(request=self.request)
+                self.client.ignore_exceptions = set(['exceptions.ValueError'])
+            self.handler.exception_handler(request=self.request)
         finally:
-            get_client().ignore_exceptions.clear()
+            self.client.ignore_exceptions.clear()
 
         assert not mock_send.called

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -635,7 +635,7 @@ class ReportViewTest(TestCase):
 
     def setUp(self):
         super(ReportViewTest, self).setUp()
-        self.path = reverse('raven-report', urlconf=self.urls)
+        self.path = reverse('raven-report', args=['1'], urlconf=self.urls)
 
     @mock.patch('raven.contrib.django.views.is_valid_origin')
     def test_calls_is_valid_origin_with_header(self, is_valid_origin):

--- a/tests/contrib/test_celery.py
+++ b/tests/contrib/test_celery.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+
+import celery
+
+from raven.contrib.celery import SentryCeleryHandler
+from raven.utils.testutils import InMemoryClient, TestCase
+
+
+class CeleryTestCase(TestCase):
+    def setUp(self):
+        super(CeleryTestCase, self).setUp()
+        self.celery = celery.Celery(__name__)
+        self.celery.conf.CELERY_ALWAYS_EAGER = True
+
+        self.client = InMemoryClient()
+        self.handler = SentryCeleryHandler(self.client, ignore_expected=True)
+        self.handler.install()
+        self.addCleanup(self.handler.uninstall)
+
+    def test_simple(self):
+        @self.celery.task(name='dummy_task')
+        def dummy_task(x, y):
+            return x / y
+
+        dummy_task.delay(1, 2)
+        dummy_task.delay(1, 0)
+        assert len(self.client.events) == 1
+        event = self.client.events[0]
+        exception = event['exception']['values'][0]
+        assert event['culprit'] == 'dummy_task'
+        assert exception['type'] == 'ZeroDivisionError'
+
+    def test_ignore_expected(self):
+        @self.celery.task(name='dummy_task', throws=(ZeroDivisionError,))
+        def dummy_task(x, y):
+            return x / y
+
+        dummy_task.delay(1, 2)
+        dummy_task.delay(1, 0)
+        assert len(self.client.events) == 0

--- a/tests/contrib/webpy/tests.py
+++ b/tests/contrib/webpy/tests.py
@@ -57,7 +57,6 @@ class WebPyTest(TestCase):
         self.assertEquals(exc['type'], 'ValueError')
         self.assertEquals(exc['value'], 'That\'s what she said')
         self.assertEquals(event['message'], 'ValueError: That\'s what she said')
-        self.assertEquals(event['culprit'], 'tests.contrib.webpy.tests in GET')
 
     def test_post(self):
         response = self.client.post('/test?biz=baz', params={'foo': 'bar'}, expect_errors=True)

--- a/tests/handlers/logging/tests.py
+++ b/tests/handlers/logging/tests.py
@@ -167,7 +167,6 @@ class LoggingIntegrationTest(TestCase):
         self.assertEqual(frame['module'], 'raven.handlers.logging')
         assert 'exception' not in event
         self.assertTrue('sentry.interfaces.Message' in event)
-        self.assertEqual(event['culprit'], 'root in make_record')
         self.assertEqual(event['message'], 'This is a test of stacks')
 
     def test_no_record_stack(self):
@@ -186,8 +185,6 @@ class LoggingIntegrationTest(TestCase):
         self.assertEqual(len(self.client.events), 1)
         event = self.client.events.pop(0)
         assert 'stacktrace' in event
-        assert 'culprit' in event
-        assert event['culprit'] == 'root in make_record'
         self.assertTrue('message' in event, event)
         self.assertEqual(event['message'], 'This is a test of stacks')
         assert 'exception' not in event

--- a/tests/utils/stacks/tests.py
+++ b/tests/utils/stacks/tests.py
@@ -6,7 +6,7 @@ import os.path
 
 from mock import Mock
 from raven.utils.testutils import TestCase
-from raven.utils.stacks import get_culprit, get_stack_info, get_lines_from_file
+from raven.utils.stacks import get_stack_info, get_lines_from_file
 
 
 class Context(object):
@@ -16,33 +16,6 @@ class Context(object):
     __getitem__ = lambda s, *a: s.dict.__getitem__(*a)
     __setitem__ = lambda s, *a: s.dict.__setitem__(*a)
     iterkeys = lambda s, *a: six.iterkeys(s.dict, *a)
-
-
-class GetCulpritTest(TestCase):
-    def test_empty_module(self):
-        culprit = get_culprit([{
-            'module': None,
-            'function': 'foo',
-        }])
-        assert culprit == '? in foo'
-
-    def test_empty_function(self):
-        culprit = get_culprit([{
-            'module': 'foo',
-            'function': None,
-        }])
-        assert culprit == 'foo in ?'
-
-    def test_no_module_or_function(self):
-        culprit = get_culprit([{}])
-        assert culprit is None
-
-    def test_all_params(self):
-        culprit = get_culprit([{
-            'module': 'package.name',
-            'function': 'foo',
-        }])
-        assert culprit == 'package.name in foo'
 
 
 class GetStackInfoTest(TestCase):
@@ -95,6 +68,7 @@ class GetStackInfoTest(TestCase):
         assert results['frames'][8]['filename'] == '8'
         assert results['frames'][9]['filename'] == '9'
 
+
 class FailLoader():
     '''
     Recreating the built-in loaders from a fake stack trace was brittle.
@@ -108,6 +82,7 @@ class FailLoader():
             raise IOError('Cannot load .zip files')
         else:
             raise ValueError('Invalid file extension')
+
 
 class GetLineFromFileTest(TestCase):
     def setUp(self):

--- a/tests/utils/test_transaction.py
+++ b/tests/utils/test_transaction.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+
+from raven.utils.transaction import TransactionStack
+
+
+def test_simple():
+    stack = TransactionStack()
+
+    stack.push('foo')
+
+    assert len(stack) == 1
+    assert stack.peek() == 'foo'
+
+    bar = stack.push(['bar'])
+
+    assert len(stack) == 2
+    assert stack.peek() == ['bar']
+
+    stack.push({'baz': True})
+
+    assert len(stack) == 3
+    assert stack.peek() == {'baz': True}
+
+    stack.pop(bar)
+
+    assert len(stack) == 1
+    assert stack.peek() == 'foo'
+
+    stack.pop()
+
+    assert len(stack) == 0
+    assert stack.peek() == None
+
+
+def test_context_manager():
+    stack = TransactionStack()
+
+    with stack('foo'):
+        assert stack.peek() == 'foo'
+
+    assert stack.peek() is None


### PR DESCRIPTION
- Implemented in Django via middleware
- Implemented in Flask via signals
- Implemented in Celery via signals
- Defer empty culprit to server (Sentry deals fills it)
- Adds SentryDjangoHandler to abstract setup/teardown of various listeners
- Adds SentryCeleryHandler to abstract setup/teardown of various listeners

For Django and Flask this will replace the culprit with a simplified URL path e.g. ``/foo/{bar}/``. For Celery this will use the registered task name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/768)
<!-- Reviewable:end -->
