### PR TITLE
Relax flake8 version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ tests_require = [
     'Django>=1.4',
     'django-celery>=2.5',
     'exam>=0.5.2',
-    'flake8>=2.0,<2.1',
+    'flake8>=2.0,<2.6',
     'logbook',
     'mock',
     'nose',


### PR DESCRIPTION
Still maintain preventive check against next major version,
which I imagine was the reason for the <2.1 in the first place.

The current restrictive range is making packaging of
raven-python needlessly difficult.