### PR TITLE
Make implicit minimum Tornado version explicit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ tests_require = [
     'pytest-django==2.9.1',
     'pytest-timeout==0.4',
     'requests',
-    'tornado',
+    'tornado>=4.1',
     'webob',
     'webtest',
     'anyjson',


### PR DESCRIPTION
TornadoTransportTests.test__sending_successfully_calls_success_callback uses gen.maybe_future, which appeared in Tornado 4.0
TornadoAsyncClientTestCase.test_sending_to_unresponsive_sentry_server_logs_error and TornadoTransportTests.test__sending_with_error_calls_error_callback use gen.sleep, which appeared in Tornado 4.1