### PR TITLE
Don't use simplejson

### DIFF
--- a/raven/utils/json.py
+++ b/raven/utils/json.py
@@ -11,10 +11,7 @@ from __future__ import absolute_import
 import codecs
 import datetime
 import uuid
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
 
 try:
     JSONDecodeError = json.JSONDecodeError


### PR DESCRIPTION
It behaves differently than stdlib json.

In fact, when simplejson is present, the JSONTest.test_decimal test fails, as the output is {"decimal": 123.45} instead of {"decimal": "Decimal(\'123.45\')"}