### PR TITLE
Fix SanitizePassword to work with binary types of http data.

### DIFF
--- a/raven/processors.py
+++ b/raven/processors.py
@@ -99,8 +99,11 @@ class SanitizePasswordsProcessor(Processor):
             if n not in data:
                 continue
 
-            if isinstance(data[n], six.string_types) and '=' in data[n]:
+            if ((isinstance(data[n], six.string_types) and '=' in data[n]) or
+                    isinstance(data[n], six.binary_type)):
                 # at this point we've assumed it's a standard HTTP query
+                if isinstance(data[n], six.binary_type):
+                    data[n] = data[n].decode()
                 querybits = []
                 for bit in data[n].split('&'):
                     chunk = bit.split('=')


### PR DESCRIPTION
Hello!
In this pull request fix to 5.1.1 version of package.

Details: SanitizePassword don't work for bytes type of http data.