### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ pygments_style = 'sphinx'
 intersphinx_mapping = {
     'http://docs.python.org/2.7': None,
     'django': ('http://docs.djangoproject.com/en/dev/', 'http://docs.djangoproject.com/en/dev/_objects/'),
-    'http://raven.readthedocs.org/en/latest': None
+    'https://raven.readthedocs.io/en/latest': None
 }
 
 

--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -343,7 +343,7 @@ Circus
 ~~~~~~
 
 If you are running Django with `circus <http://circus.rtfd.org/>`_ and
-`chaussette <http://chaussette.readthedocs.org/>`_ you will also need
+`chaussette <https://chaussette.readthedocs.io/>`_ you will also need
 to add a hook to circus to activate Raven::
 
     from django.conf import settings

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Raven is a Python client for `Sentry <http://getsentry.com/>`_. It provides
 full out-of-the-box support for many of the popular frameworks, including
 `Django <djangoproject.com>`_, `Flask <http://flask.pocoo.org/>`_, and `Pylons
 <http://www.pylonsproject.org/>`_. Raven also includes drop-in support for any
-`WSGI <http://wsgi.readthedocs.org/>`_-compatible web application.
+`WSGI <https://wsgi.readthedocs.io/>`_-compatible web application.
 """
 
 # Hack to prevent stupid "TypeError: 'NoneType' object is not callable" error


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.