### PR TITLE
Add type check for sentry initialization for flask

### DIFF
--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -105,6 +105,9 @@ class Sentry(object):
     def __init__(self, app=None, client=None, client_cls=Client, dsn=None,
                  logging=False, logging_exclusions=None, level=logging.NOTSET,
                  wrap_wsgi=None, register_signal=True):
+        if client and not isinstance(client, Client):
+            raise TypeError('client should an instance of Client')
+
         self.dsn = dsn
         self.logging = logging
         self.logging_exclusions = logging_exclusions

--- a/tests/contrib/flask/tests.py
+++ b/tests/contrib/flask/tests.py
@@ -283,6 +283,9 @@ class FlaskTest(BaseTest):
         some_other_logger = logging.getLogger("some_other_logger")
         self.assertTrue(some_other_logger.propagate)
 
+    def test_check_client_type(self):
+        self.assertRaises(TypeError, lambda _: Sentry(self.app, "oops, I'm putting my DSN instead"))
+
 
 class FlaskLoginTest(BaseTest):
 


### PR DESCRIPTION
To avoid an unrelated error when doing a `Sentry(app, dsn)`

(as discussed with @mitsuhiko on IRC)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/792)
<!-- Reviewable:end -->
