### PR TITLE
Added IOError to get stack info for graceful zip import errors

### DIFF
--- a/raven/utils/stacks.py
+++ b/raven/utils/stacks.py
@@ -30,7 +30,7 @@ def get_lines_from_file(filename, lineno, context_lines,
     if loader is not None and hasattr(loader, "get_source"):
         try:
             source = loader.get_source(module_name)
-        except ImportError:
+        except (ImportError, IOError):
             # Traceback (most recent call last):
             #   File "/Users/dcramer/Development/django-sentry/sentry/client/handlers.py", line 31, in emit
             #     get_client().create_from_record(record, request=request)


### PR DESCRIPTION
This PR addresses an issue where zip path imports can crash sentry in a manner similar to cProfile -- see comment/blame commit below IOError addition -- with an IOError instead of just an ImportError. Specifically this occurs if the source zip code is no longer accessible to the program (easy to trigger with an uncaught exception in PySpark codebases).

I added some tests to check for the capture with a fake loader object. Given the method has no expectations for the type of loader it seemed fine to just pass an object which always raises the tested exceptions. Additionally it was taking an excessive amount of scaffolding with fake errors to capture the actual loader which exhibits the behaviour, and is difficult to guarantee that loader will have a `get_source` method, which causes it to skip testing the critical path when absent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/793)
<!-- Reviewable:end -->
