### PR TITLE
Fix Django LOGGING example root logger

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -84,10 +84,6 @@ ERROR and above messages to sentry, the following config can be used::
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': True,
-        'root': {
-            'level': 'WARNING',
-            'handlers': ['sentry'],
-        },
         'formatters': {
             'verbose': {
                 'format': '%(levelname)s %(asctime)s %(module)s '
@@ -107,6 +103,10 @@ ERROR and above messages to sentry, the following config can be used::
             }
         },
         'loggers': {
+            'root': {
+                'level': 'WARNING',
+                'handlers': ['sentry'],
+            },
             'django.db.backends': {
                 'level': 'ERROR',
                 'handlers': ['console'],


### PR DESCRIPTION
We used the example Django configuration you provide in docs but had tons of debug logs in production because the root logger configuration was ignored. By placing it in `loggers` like the other loggers, we no longer have all those debug logs.

This is very close to what the [`logging` example is currently doing](https://github.com/getsentry/raven-python/blob/0a90d8d3592caf2969273f0cff4de906ca8ff7d9/docs/integrations/logging.rst). The difference is that we did not try specifying the root logger as `''` because `'root'` works. This [2014 Stack Overflow question](http://stackoverflow.com/questions/21021704/configuring-root-logger-in-python) seems to imply that using `''` as a root logger name in Django does not work. Overall, this appears to be tricky enough that I would not recommend merging this pull request without checking that I'm not hallucinating here.

Thanks for Sentry!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/794)
<!-- Reviewable:end -->
