### PR TITLE
Django client template_debug's source_lines is just a snippet

### DIFF
--- a/raven/contrib/django/utils.py
+++ b/raven/contrib/django/utils.py
@@ -23,12 +23,13 @@ def linebreak_iter(template_source):
 
 def get_data_from_template(source, debug=None):
     if debug is not None:
-        start = debug['start']
-        end = debug['end']
-        source_lines = debug['source_lines']
         lineno = debug['line']
         filename = debug['name']
-        culprit = filename.split('/templates/')[-1]
+        source_lines = []
+        source_lines += [''] * (debug['source_lines'][0][0])
+        for num, line in debug['source_lines']:
+            source_lines.append(line)
+        source_lines += [''] * 4
     elif source:
         origin, (start, end) = source
         filename = culprit = getattr(origin, 'loadname', None)
@@ -49,6 +50,9 @@ def get_data_from_template(source, debug=None):
 
     if filename is None:
         filename = '<unknown filename>'
+        culprit = '<unknown filename>'
+    else:
+        culprit = filename.split('/templates/')[-1]
 
     pre_context = source_lines[max(lineno - 3, 0):lineno]
     post_context = source_lines[(lineno + 1):(lineno + 4)]


### PR DESCRIPTION
When using the Jinja2 template engine over the built-in Django one I came across this bug where get_data_from_template was itself breaking. As a result, when debugging, I would get the template error in my browser, but raven would never send the exception to my Sentry server as execution stopped in this function.

In the template_debug field of the Exception, the source_lines is actually a snippet, not the full source of the template source_lines is also list of tuples, not just a list of lines in the form of [(linenbr, 'line-detail'), (linenbr, 'line-detail'), ...]

So I generate source_lines starting with an empty list, adding blank lines until we get to the snippet, then add the snippet as a list.

Also, debug['start'] and debug['end'] didn't exist (although they do when using the Django template engine), but  I removed these lines because start and end are never used elsewhere in the function (only in the source elif branch)

Finally, if the context_line was the last line of the template, I padded source_lines with a few extra post_context does not break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/796)
<!-- Reviewable:end -->
