### PR TITLE
Remove data from error message

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -628,9 +628,10 @@ class Client(object):
                 type(exc).__name__, exc.message)
         else:
             self.error_logger.error(
-                'Sentry responded with an error: %s (url: %s)\n%s',
-                exc, url, pformat(data),
-                exc_info=True
+                'Sentry responded with an error: %s (url: %s)',
+                exc, url,
+                exc_info=True,
+                extra={'data': data}
             )
 
         self._log_failed_submission(data)


### PR DESCRIPTION
data variable can contain a lot of information, sending along with the error
message will print too much informations

Fixes #799

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/800)
<!-- Reviewable:end -->
