### PR TITLE
Do not log exceptions from the django cli client twice

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -59,6 +59,13 @@ SDK_VALUE = {
 Raven = None
 
 
+def get_excepthook_client():
+    hook = sys.excepthook
+    client = getattr(hook, 'raven_client', None)
+    if client is not None:
+        return client
+
+
 class ModuleProxyCache(dict):
     def __missing__(self, key):
         module, class_name = key.rsplit('.', 1)
@@ -237,6 +244,7 @@ class Client(object):
         def handle_exception(*exc_info):
             self.captureException(exc_info=exc_info)
             __excepthook__(*exc_info)
+        handle_exception.raven_client = self
         sys.excepthook = handle_exception
 
     def install_logging_hook(self):

--- a/raven/contrib/django/management/__init__.py
+++ b/raven/contrib/django/management/__init__.py
@@ -18,7 +18,7 @@ def patch_cli_runner():
     Patches ``cls.execute``, returning a boolean describing if the
     attempt was successful.
     """
-    from raven.baes import get_excepthook_client
+    from raven.base import get_excepthook_client
 
     try:
         from django.core.management.base import BaseCommand

--- a/raven/contrib/django/management/__init__.py
+++ b/raven/contrib/django/management/__init__.py
@@ -18,6 +18,8 @@ def patch_cli_runner():
     Patches ``cls.execute``, returning a boolean describing if the
     attempt was successful.
     """
+    from raven.baes import get_excepthook_client
+
     try:
         from django.core.management.base import BaseCommand
     except ImportError:
@@ -42,9 +44,13 @@ def patch_cli_runner():
         except Exception:
             from raven.contrib.django.models import client
 
-            client.captureException(extra={
-                'argv': sys.argv
-            })
+            # Since this is an unhandled exception that falls through
+            # we only want to log it if the given client is not the
+            # one that handles the global exceptions.
+            if get_excepthook_client() is not client:
+                client.captureException(extra={
+                    'argv': sys.argv
+                })
             raise
 
     new_execute.__raven_patched = True


### PR DESCRIPTION
This fixes #802

@dcramer thoughts?

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/805)
<!-- Reviewable:end -->
