### PR TITLE
Add ignore_exceptions to client configuration

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -129,6 +129,16 @@ The following are valid arguments which may be passed to the Raven client:
             'lxml.objectify',
         ]
 
+.. describe:: ignore_exceptions
+
+    A list of exceptions to ignore.
+
+        ignore_exceptions = [
+            'Http404',
+            'django.exceptions.http.Http404',
+            'django.exceptions.*',
+        ]
+
 .. describe:: max_list_length
 
     The maximum number of items a list-like container should store.

--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -137,6 +137,7 @@ def get_client(client=None, reset=False):
         options.setdefault('dsn', ga('DSN'))
         options.setdefault('context', ga('CONTEXT'))
         options.setdefault('release', ga('RELEASE'))
+        options.setdefault('ignore_exceptions', ga('IGNORE_EXCEPTIONS'))
 
         transport = ga('TRANSPORT') or options.get('transport')
         if isinstance(transport, string_types):
@@ -160,17 +161,6 @@ def get_client(client=None, reset=False):
 
 
 def sentry_exception_handler(request=None, **kwargs):
-    exc_type = sys.exc_info()[0]
-
-    exclusions = set(get_option('IGNORE_EXCEPTIONS', ()))
-
-    exc_name = '%s.%s' % (exc_type.__module__, exc_type.__name__)
-    if exc_type.__name__ in exclusions or exc_name in exclusions or any(exc_name.startswith(e[:-1]) for e in exclusions if e.endswith('*')):
-        logger.info(
-            'Not capturing exception due to filters: %s', exc_type,
-            exc_info=sys.exc_info())
-        return
-
     try:
         client.captureException(exc_info=sys.exc_info(), request=request)
     except Exception as exc:

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -755,39 +755,40 @@ class SentryExceptionHandlerTest(TestCase):
 
         captureException.assert_called_once_with(exc_info=self.exc_info, request=self.request)
 
-    @mock.patch.object(TempStoreClient, 'captureException')
+    @mock.patch.object(TempStoreClient, 'capture')
     @mock.patch('sys.exc_info')
-    @mock.patch('raven.contrib.django.models.get_option')
-    def test_does_exclude_filtered_types(self, get_option, exc_info, captureException):
+    def test_does_exclude_filtered_types(self, exc_info, mock_capture):
         exc_info.return_value = self.exc_info
-        get_option.return_value = ['ValueError']
+        get_client().ignore_exceptions = set(['ValueError'])
 
         sentry_exception_handler(request=self.request)
 
-        assert not captureException.called
+        assert not mock_capture.called
 
-    @mock.patch.object(TempStoreClient, 'captureException')
+    @mock.patch.object(TempStoreClient, 'capture')
     @mock.patch('sys.exc_info')
-    @mock.patch('raven.contrib.django.models.get_option')
-    def test_ignore_exceptions_with_expression_match(self, get_option, exc_info, captureException):
+    def test_ignore_exceptions_with_expression_match(self, exc_info, mock_capture):
         exc_info.return_value = self.exc_info
-        get_option.return_value = ['builtins.*']
-        if not six.PY3:
-            get_option.return_value = ['exceptions.*']
+
+        if six.PY3:
+            get_client().ignore_exceptions = set(['builtins.*'])
+        else:
+            get_client().ignore_exceptions = set(['exceptions.*'])
 
         sentry_exception_handler(request=self.request)
 
-        assert not captureException.called
+        assert not mock_capture.called
 
-    @mock.patch.object(TempStoreClient, 'captureException')
+    @mock.patch.object(TempStoreClient, 'capture')
     @mock.patch('sys.exc_info')
-    @mock.patch('raven.contrib.django.models.get_option')
-    def test_ignore_exceptions_with_module_match(self, get_option, exc_info, captureException):
+    def test_ignore_exceptions_with_module_match(self, exc_info, mock_capture):
         exc_info.return_value = self.exc_info
-        get_option.return_value = ['builtins.ValueError']
-        if not six.PY3:
-            get_option.return_value = ['exceptions.ValueError']
+
+        if six.PY3:
+            get_client().ignore_exceptions = set(['builtins.ValueError'])
+        else:
+            get_client().ignore_exceptions = set(['exceptions.ValueError'])
 
         sentry_exception_handler(request=self.request)
 
-        assert not captureException.called
+        assert not mock_capture.called


### PR DESCRIPTION
This takes Django's IGNORE_EXCEPTIONS support and moves it into core.

@getsentry/python

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/807)
<!-- Reviewable:end -->
