### PR TITLE
Default Raven instance

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -44,7 +44,7 @@ from raven.transport.registry import TransportRegistry, default_transports
 import raven.events  # NOQA
 
 
-__all__ = ('Client',)
+__all__ = ('Client', 'Raven')
 
 __excepthook__ = None
 
@@ -55,7 +55,7 @@ SDK_VALUE = {
     'version': raven.VERSION,
 }
 
-# singleton for the client
+# Singleton for Client
 Raven = None
 
 
@@ -137,7 +137,8 @@ class Client(object):
 
     def __init__(self, dsn=None, raise_send_errors=False, transport=None,
                  install_sys_hook=True, install_logging_hook=True,
-                 hook_libraries=None, enable_breadcrumbs=True, **options):
+                 hook_libraries=None, enable_breadcrumbs=True,
+                 _check_enabled_status=True, **options):
         global Raven
 
         o = options
@@ -182,7 +183,7 @@ class Client(object):
 
         self.module_cache = ModuleProxyCache()
 
-        if not self.is_enabled():
+        if _check_enabled_status and not self.is_enabled():
             self.logger.info(
                 'Raven is not configured (logging is disabled). Please see the'
                 ' documentation for more information.')
@@ -847,3 +848,7 @@ class DummyClient(Client):
     "Sends messages into an empty void"
     def send(self, **kwargs):
         return None
+
+
+# Bind default client at runtime
+Raven = Client(_check_enabled_status=False)


### PR DESCRIPTION
This creates a default client instance at runtime which eliminates the need to do anything other than 'import raven' if SENTRY_DSN is set.

We can also leverage this to move more towards setters rather than client instantiation going forward.

@getsentry/python

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/809)
<!-- Reviewable:end -->
