### PR TITLE
Address issue #810: tox error running tests more than once.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,4 @@ include/
 lib/
 .cache
 .idea
-.eggs
 venv

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 envlist = py26, py27, py33, py34, py35, pypy
 
 [testenv]
+deps =
+    .[tests]
 commands =
-    pip install -e .[tests]
     python setup.py test


### PR DESCRIPTION
Tox is designed to handle its own test environment setup and teardown,
so this change replaces the manual environment "setup" step in the Tox
test command section with an appropriate setting for test dependencies.

This fixes the following error:

Running, say:

```
$ tox -e py35
```

would result in an error like the following on test runs after the first:

```
Traceback (most recent call last):
  File "/.../raven-python/.tox/py35/lib/python3.5/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/.../raven-python/.tox/py35/lib/python3.5/site-packages/pip/commands/install.py", line 317, in run
    prefix=options.prefix_path,
  File "/.../raven-python/.tox/py35/lib/python3.5/site-packages/pip/req/req_set.py", line 736, in install
    requirement.uninstall(auto_confirm=True)
  File "/.../raven-python/.tox/py35/lib/python3.5/site-packages/pip/req/req_install.py", line 687, in uninstall
    '(at %s)' % (link_pointer, self.name, dist.location)
AssertionError: Egg-link /.../raven-python does not match installed location of raven (at /.../raven-python/.tox/py35/lib/python3.5/site-packages)

__________________________________________________________________________________ summary __________________________________________________________________________________
ERROR:   py35: InvocationError: /.../raven-python/.tox/py35/bin/pip install -U --no-deps /.../raven-python/.tox/dist/raven-5.23.0.zip (see /.../raven-python/.tox/py35/log/py35-3.log)
```

This commit also removes from .gitignore the line that was added in
the commit that originally added the manual setup step removed here (which
was commit 99a4fbbe81948f6fe4fc422531c6770609988b58 ).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/817)

<!-- Reviewable:end -->
