### PR TITLE
Fix warnings from Pytest 3.0+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 python_files=test*.py
 addopts=--tb=native -p no:doctest
 norecursedirs=bin dist docs htmlcov hooks node_modules .* {args}

--- a/tests/contrib/bottle/tests.py
+++ b/tests/contrib/bottle/tests.py
@@ -1,6 +1,6 @@
 from exam import fixture
 
-from webtest import TestApp
+from webtest import TestApp as WebtestApp  # prevent pytest-warning
 
 import bottle
 
@@ -25,7 +25,7 @@ def create_app(raven):
     app = bottle.app()
     app.catchall = False
     app = Sentry(app, client=raven)
-    tapp = TestApp(app)
+    tapp = WebtestApp(app)
 
     @bottle.route('/error/', ['GET', 'POST'])
     def an_error():

--- a/tests/contrib/django/models.py
+++ b/tests/contrib/django/models.py
@@ -3,5 +3,5 @@ from __future__ import absolute_import
 from django.db import models
 
 
-class TestModel(models.Model):
+class MyTestModel(models.Model):
     pass

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -35,8 +35,8 @@ from raven.contrib.django.views import is_valid_origin
 from raven.transport import HTTPTransport
 from raven.utils.serializer import transform
 
-from django.test.client import Client as TestClient, ClientHandler as TestClientHandler
-from .models import TestModel
+from django.test.client import Client as DjangoTestClient, ClientHandler as DjangoTestClientHandler
+from .models import MyTestModel
 
 settings.SENTRY_CLIENT = 'tests.contrib.django.tests.TempStoreClient'
 
@@ -55,7 +55,7 @@ def make_request():
     })
 
 
-class MockClientHandler(TestClientHandler):
+class MockClientHandler(DjangoTestClientHandler):
     def __call__(self, environ, start_response=[]):
         # this pretends doesn't require start_response
         return super(MockClientHandler, self).__call__(environ)
@@ -256,7 +256,7 @@ class DjangoClientTest(TestCase):
 
     def test_broken_500_handler_with_middleware(self):
         with Settings(BREAK_THAT_500=True, INSTALLED_APPS=['raven.contrib.django']):
-            client = TestClient(REMOTE_ADDR='127.0.0.1')
+            client = DjangoTestClient(REMOTE_ADDR='127.0.0.1')
             client.handler = MockSentryMiddleware(MockClientHandler())
 
             self.assertRaises(Exception, client.get, reverse('sentry-raise-exc'))
@@ -733,21 +733,21 @@ class PromiseSerializerTestCase(TestCase):
 
 class ModelInstanceSerializerTestCase(TestCase):
     def test_basic(self):
-        instance = TestModel()
+        instance = MyTestModel()
 
         result = transform(instance)
         assert isinstance(result, six.string_types)
-        assert result == '<TestModel: TestModel object>'
+        assert result == '<MyTestModel: MyTestModel object>'
 
 
 class QuerySetSerializerTestCase(TestCase):
     def test_basic(self):
         from django.db.models.query import QuerySet
-        obj = QuerySet(model=TestModel)
+        obj = QuerySet(model=MyTestModel)
 
         result = transform(obj)
         assert isinstance(result, six.string_types)
-        assert result == '<QuerySet: model=TestModel>'
+        assert result == '<QuerySet: model=MyTestModel>'
 
 
 class SentryExceptionHandlerTest(TestCase):

--- a/tests/contrib/webpy/tests.py
+++ b/tests/contrib/webpy/tests.py
@@ -1,5 +1,5 @@
 from exam import fixture
-from paste.fixture import TestApp
+from paste.fixture import TestApp as PasteTestApp  # prevent pytest-warning
 
 from raven.base import Client
 from raven.contrib.webpy import SentryApplication
@@ -43,7 +43,7 @@ class WebPyTest(TestCase):
 
     @fixture
     def client(self):
-        return TestApp(self.app.wsgifunc())
+        return PasteTestApp(self.app.wsgifunc())
 
     def test_get(self):
         resp = self.client.get('/test', expect_errors=True)


### PR DESCRIPTION
Fix WC1 warnings from the below:

```
============================================================== pytest-warning summary ==============================================================
WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.
WI1 /Users/adamj/Documents/Projects/raven-python/.tox/py27/lib/python2.7/site-packages/pytest_timeout.py:68 'pytest_runtest_protocol' hook uses deprecated __multicall__ argument
WC1 /Users/adamj/Documents/Projects/raven-python/tests/contrib/bottle/tests.py cannot collect test class 'TestApp' because it has a __init__ constructor
WC1 /Users/adamj/Documents/Projects/raven-python/tests/contrib/django/tests.py cannot collect test class 'ClientHandler' because it has a __init__ constructor
WC1 /Users/adamj/Documents/Projects/raven-python/tests/contrib/django/tests.py cannot collect test class 'Client' because it has a __init__ constructor
WC1 /Users/adamj/Documents/Projects/raven-python/tests/contrib/django/tests.py cannot collect test class 'TestModel' because it has a __init__ constructor
WC1 /Users/adamj/Documents/Projects/raven-python/tests/contrib/webpy/tests.py cannot collect test class 'TestApp' because it has a __init__ constructor
```

`setup.cfg` fixed as per pytest-dev/pytest#567. `cannot collect test class` fixed by renaming the affected class names so the collector doesn't consider them.

The WI1 warning is left as it's in the `pytest_timeout` plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/839)
<!-- Reviewable:end -->
