### PR TITLE
Fix one usage of `get_ident`

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -282,7 +282,7 @@ class DjangoClient(Client):
             # attach the sentry object to the request
             request.sentry = {
                 'project_id': data.get('project', self.remote.project),
-                'id': self.get_ident(result),
+                'id': result,
             }
 
         return result


### PR DESCRIPTION
This gets rid of the corresponding DeprecationWarning when using
DjangoClient.capture:

> /Users/abc/.venv/lib/python2.7/site-packages/raven/base.py:290:
DeprecationWarning: Client.get_ident is deprecated. The event ID is now returned
as the result of capture.
>  DeprecationWarning)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/843)
<!-- Reviewable:end -->
