### PR TITLE
Fix get_user_info for Django 1.10 when is_authenticated is a property

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -140,9 +140,14 @@ class DjangoClient(Client):
         install_sql_hook()
 
     def get_user_info(self, user):
-        if hasattr(user, 'is_authenticated') and \
-           not user.is_authenticated():
-            return None
+        if hasattr(user, 'is_authenticated'):
+            # is_authenticated was a method in Django < 1.10
+            if callable(user.is_authenticated):
+                authenticated = user.is_authenticated()
+            else:
+                authenticated = user.is_authenticated
+            if not authenticated:
+                return None
 
         user_info = {}
         try:


### PR DESCRIPTION
This changes fixes #845.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/846)
<!-- Reviewable:end -->
