### PR TITLE
By default don't import 3rd-party Python modules, only stdlib ones.  …

### DIFF
--- a/raven/transport/__init__.py
+++ b/raven/transport/__init__.py
@@ -9,13 +9,13 @@ raven.transport
 # manually import/register transports somehow
 from __future__ import absolute_import
 
-from raven.transport.base import *  # NOQA
-from raven.transport.eventlet import *  # NOQA
-from raven.transport.exceptions import *  # NOQA
-from raven.transport.gevent import *  # NOQA
-from raven.transport.http import *  # NOQA
-from raven.transport.requests import *  # NOQA
-from raven.transport.registry import *  # NOQA
-from raven.transport.twisted import *  # NOQA
-from raven.transport.threaded import *  # NOQA
-from raven.transport.tornado import *  # NOQA
+# from raven.transport.base import *  # NOQA
+# from raven.transport.eventlet import *  # NOQA
+# from raven.transport.exceptions import *  # NOQA
+# from raven.transport.gevent import *  # NOQA
+# from raven.transport.http import *  # NOQA
+# from raven.transport.requests import *  # NOQA
+# from raven.transport.registry import *  # NOQA
+# from raven.transport.twisted import *  # NOQA
+# from raven.transport.threaded import *  # NOQA
+# from raven.transport.tornado import *  # NOQA

--- a/raven/transport/registry.py
+++ b/raven/transport/registry.py
@@ -8,15 +8,15 @@ raven.transport.registry
 from __future__ import absolute_import
 
 # TODO(dcramer): we really should need to import all of these by default
-from raven.transport.eventlet import EventletHTTPTransport
+# from raven.transport.eventlet import EventletHTTPTransport
 from raven.transport.exceptions import DuplicateScheme
 from raven.transport.http import HTTPTransport
-from raven.transport.gevent import GeventedHTTPTransport
-from raven.transport.requests import RequestsHTTPTransport
+# from raven.transport.gevent import GeventedHTTPTransport
+# from raven.transport.requests import RequestsHTTPTransport
 from raven.transport.threaded import ThreadedHTTPTransport
 from raven.transport.threaded_requests import ThreadedRequestsHTTPTransport
-from raven.transport.twisted import TwistedHTTPTransport
-from raven.transport.tornado import TornadoHTTPTransport
+# from raven.transport.twisted import TwistedHTTPTransport
+# from raven.transport.tornado import TornadoHTTPTransport
 from raven.utils import urlparse
 
 
@@ -74,10 +74,10 @@ class TransportRegistry(object):
 default_transports = [
     HTTPTransport,
     ThreadedHTTPTransport,
-    GeventedHTTPTransport,
-    TwistedHTTPTransport,
-    RequestsHTTPTransport,
-    ThreadedRequestsHTTPTransport,
-    TornadoHTTPTransport,
-    EventletHTTPTransport,
+    # GeventedHTTPTransport,
+    # TwistedHTTPTransport,
+    # RequestsHTTPTransport,
+    # ThreadedRequestsHTTPTransport,
+    # TornadoHTTPTransport,
+    # EventletHTTPTransport,
 ]

--- a/raven/transport/threaded_requests.py
+++ b/raven/transport/threaded_requests.py
@@ -8,7 +8,7 @@ raven.transport.threaded_requests
 from __future__ import absolute_import
 
 from raven.transport.base import AsyncTransport
-from raven.transport import RequestsHTTPTransport
+from raven.transport.requests import RequestsHTTPTransport
 from raven.transport.threaded import AsyncWorker
 
 


### PR DESCRIPTION
…Fixes #854.