### PR TITLE
_log_failed_submission fails with malformed exceptions

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -657,9 +657,9 @@ class Client(object):
             # try to reconstruct a reasonable version of the exception
             for frame in data['exception']['values'][0]['stacktrace']['frames']:
                 output.append('  File "%(fn)s", line %(lineno)s, in %(func)s' % {
-                    'fn': frame['filename'],
-                    'lineno': frame['lineno'],
-                    'func': frame['function'],
+                    'fn': frame.get('filename', 'unknown_filename'),
+                    'lineno': frame.get('lineno', -1),
+                    'func': frame.get('function', 'unknown_function'),
                 })
 
         self.uncaught_logger.error(output)


### PR DESCRIPTION
This will manifest in those kind of errors:

```
        if 'exception' in data and 'stacktrace' in data['exception']['values'][0]:
            # try to reconstruct a reasonable version of the exception
            for frame in data['exception']['values'][0]['stacktrace']['frames']:
                output.append('  File "%(fn)s", line %(lineno)s, in %(func)s' % {
>                   'fn': frame['filename'],
                    'lineno': frame['lineno'],
                    'func': frame['function'],
                })
E               KeyError: 'filename'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/859)
<!-- Reviewable:end -->
