### PR TITLE
Add support for Django 1.10-style middleware via `MiddlewareMixin`

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -144,11 +144,11 @@ In certain conditions you may wish to log 404 events to the Sentry server. To
 do this, you simply need to enable a Django middleware:
 
 .. sourcecode:: python
-
-    MIDDLEWARE_CLASSES = (
+    # Use ``MIDDLEWARE_CLASSES`` prior to Django 1.10
+    MIDDLEWARE = (
         'raven.contrib.django.raven_compat.middleware.Sentry404CatchMiddleware',
         ...,
-    ) + MIDDLEWARE_CLASSES
+    ) + MIDDLEWARE
 
 It is recommended to put the middleware at the top, so that any only 404s
 that bubbled all the way up get logged. Certain middlewares (e.g. flatpages)
@@ -175,8 +175,8 @@ Sentry supports sending a message ID to your clients so that they can be
 tracked easily by your development team. There are two ways to access this
 information, the first is via the ``X-Sentry-ID`` HTTP response header.
 Adding this is as simple as appending a middleware to your stack::
-
-    MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + (
+    # Use ``MIDDLEWARE_CLASSES`` prior to Django 1.10
+    MIDDLEWARE = MIDDLEWARE + (
       # We recommend putting this as high in the chain as possible
       'raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',
       ...,

--- a/raven/contrib/django/middleware/__init__.py
+++ b/raven/contrib/django/middleware/__init__.py
@@ -14,6 +14,14 @@ import threading
 from django.conf import settings
 from django.core.signals import request_finished
 
+try:
+    # Django >= 1.10
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object
+
 from raven.contrib.django.resolver import RouteResolver
 
 
@@ -27,7 +35,7 @@ def is_ignorable_404(uri):
     )
 
 
-class Sentry404CatchMiddleware(object):
+class Sentry404CatchMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         from raven.contrib.django.models import client
 
@@ -52,7 +60,7 @@ class Sentry404CatchMiddleware(object):
     # sentry_exception_handler(sender=Sentry404CatchMiddleware, request=request)
 
 
-class SentryResponseErrorIdMiddleware(object):
+class SentryResponseErrorIdMiddleware(MiddlewareMixin):
     """
     Appends the X-Sentry-ID response header for referencing a message within
     the Sentry datastore.

--- a/raven/contrib/django/middleware/wsgi.py
+++ b/raven/contrib/django/middleware/wsgi.py
@@ -7,11 +7,19 @@ raven.contrib.django.middleware.wsgi
 """
 from __future__ import absolute_import
 
+try:
+    # Django >= 1.10
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object
+
 from raven.middleware import Sentry
 from raven.utils import memoize
 
 
-class Sentry(Sentry):
+class Sentry(Sentry, MiddlewareMixin):
     """
     Identical to the default WSGI middleware except that
     the client comes dynamically via ``get_client

--- a/tests/contrib/django/middleware.py
+++ b/tests/contrib/django/middleware.py
@@ -1,13 +1,22 @@
-class BrokenRequestMiddleware(object):
+try:
+    # Django >= 1.10
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object
+
+
+class BrokenRequestMiddleware(MiddlewareMixin):
     def process_request(self, request):
         raise ImportError('request')
 
 
-class BrokenResponseMiddleware(object):
+class BrokenResponseMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         raise ImportError('response')
 
 
-class BrokenViewMiddleware(object):
+class BrokenViewMiddleware(MiddlewareMixin):
     def process_view(self, request, func, args, kwargs):
         raise ImportError('view')


### PR DESCRIPTION
- [x] Implement `MiddlewareMixin` if we're able to import it (>= 1.10)
- [x] Update docs to mention both `MIDDLEWARE` and `MIDDLEWARE_CLASSES`
- [ ] Add tests with both old-style and 1.10-style middleware in `tests/contrib/django/tests.py`
- [ ] Configure `install_middleware()` to work with both `MIDDLEWARE` and `MIDDLEWARE_CLASSES`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/860)
<!-- Reviewable:end -->

