### PR TITLE
Adding docs for environment arg

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -105,6 +105,12 @@ The following are valid arguments which may be passed to the Raven client:
 
         release = '1.0.3'
 
+.. describe:: environment
+
+    The environment your application is running in::
+
+        environment = 'staging'
+
 .. describe:: exclude_paths
 
     Extending this allow you to ignore module prefixes when we attempt to


### PR DESCRIPTION
Updating Python docs to include newly added [environment argument](https://blog.sentry.io/2016/07/22/environment-details.html).

Added in response to [SO question](http://stackoverflow.com/questions/39635027/configure-sentry-for-different-environments-staging-production).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/871)
<!-- Reviewable:end -->
