### PR TITLE
`list_max_length` not `max_list_length`

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -145,7 +145,7 @@ The following are valid arguments which may be passed to the Raven client:
             'django.exceptions.*',
         ]
 
-.. describe:: max_list_length
+.. describe:: list_max_length
 
     The maximum number of items a list-like container should store.
 


### PR DESCRIPTION
Fixes a small typo in the name of the configuration parameter in the docs. I believe https://github.com/getsentry/raven-python/blob/256667349bf883624b2caa6b02ebec62b4deac15/raven/utils/conf.py#L46 confirms the actual name of the dictionary key read.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/872)
<!-- Reviewable:end -->
