### PR TITLE
Fix unreferenced variable in get_user_info

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -161,14 +161,14 @@ class DjangoClient(Client):
                 user_info['username'] = user.get_username()
             elif hasattr(user, 'username'):
                 user_info['username'] = user.username
+
+            return user_info
         except Exception:
             # We expect that user objects can be somewhat broken at times
             # and try to just handle as much as possible and ignore errors
             # as good as possible here.
-            pass
+            return None
 
-        if user_info:
-            return user_info
 
     def get_data_from_request(self, request):
         result = {}

--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -169,7 +169,6 @@ class DjangoClient(Client):
             # as good as possible here.
             return None
 
-
     def get_data_from_request(self, request):
         result = {}
 


### PR DESCRIPTION
The previous fix (#862) left the code broken, since in case of exception, `user_info` was not declared.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-python/874)
<!-- Reviewable:end -->
