### PR TITLE
Fix another usage of `get_ident`

### DIFF
--- a/raven/scripts/runner.py
+++ b/raven/scripts/runner.py
@@ -70,7 +70,7 @@ def send_test_message(client, options):
     sys.stdout.write('Sending a test message... ')
     sys.stdout.flush()
 
-    ident = client.get_ident(client.captureMessage(
+    ident = client.captureMessage(
         message='This is a test message generated using ``raven test``',
         data=data,
         level=logging.INFO,
@@ -80,7 +80,7 @@ def send_test_message(client, options):
             'user': get_uid(),
             'loadavg': get_loadavg(),
         },
-    ))
+    )
 
     sys.stdout.write('Event ID was %r\n' % (ident,))
 


### PR DESCRIPTION
This gets rid of the corresponding `DeprecationWarning` when running
`./manage.py raven test`:

2016-10-01 12:16:45,452 py.warnings WARNING: /Users/abc/.venv/lib/python2.7/site-packages/raven/base.py:297:
DeprecationWarning: Client.get_ident is deprecated. The event ID is now returned as the result of capture.
  DeprecationWarning)