### PR TITLE
Minimal support for rest_framework

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Version 5.27.0
 --------------
 
+* Added support for extracting data from rest_framework in Django integration
 * Updated CA bundle.
 * Added transaction-based culprits for Celery, Django, and Flask.
 * Fixed an issue where ``ignore_exceptions`` wasn't respected.

--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -34,6 +34,14 @@ from raven._compat import string_types, binary_type
 
 __all__ = ('DjangoClient',)
 
+VALID_HTTP_REQUESTS = (HttpRequest, )
+
+try:
+    from rest_framework.request import Request
+    VALID_HTTP_REQUESTS += (Request, )
+except ImportError:
+    pass
+
 
 class _FormatConverter(object):
 
@@ -257,7 +265,7 @@ class DjangoClient(Client):
         if request is None:
             request = getattr(SentryLogMiddleware.thread, 'request', None)
 
-        is_http_request = isinstance(request, HttpRequest)
+        is_http_request = isinstance(request, VALID_HTTP_REQUESTS)
         if is_http_request:
             data.update(self.get_data_from_request(request))
 


### PR DESCRIPTION
rest_framework uses its own request object which is not a subclass of djangos request class. Both classes are common enough that the DjangoClient can extract additional metadata from a rest_framework request.