### PR TITLE
Fix Django 1.10 MIDDLEWARE_CLASSES warning

### DIFF
--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -230,11 +230,17 @@ def install_middleware():
     name = 'raven.contrib.django.middleware.SentryMiddleware'
     all_names = (name, 'raven.contrib.django.middleware.SentryLogMiddleware')
     with settings_lock:
-        middleware_list = set(settings.MIDDLEWARE_CLASSES)
-        if not any(n in middleware_list for n in all_names):
-            settings.MIDDLEWARE_CLASSES = (
-                name,
-            ) + tuple(settings.MIDDLEWARE_CLASSES)
+        # default settings.MIDDLEWARE is None
+        middleware_attr = 'MIDDLEWARE' if getattr(settings,
+                                                  'MIDDLEWARE',
+                                                  None) is not None \
+            else 'MIDDLEWARE_CLASSES'
+        # make sure to get an empty tuple when attr is None
+        middleware = getattr(settings, middleware_attr, ()) or ()
+        if set(all_names).isdisjoint(set(middleware)):
+            setattr(settings,
+                    middleware_attr,
+                    (name,) + tuple(middleware))
 
 
 if (


### PR DESCRIPTION
This is to fix the following warning message in Django 1.10:
```
?: (1_10.W001) The MIDDLEWARE_CLASSES setting is deprecated in Django 1.10 and the MIDDLEWARE setting takes precedence. Since you've set MIDDLEWARE, the value of MIDDLEWARE_CLASSES is ignored.
```
It is because previous logic will always touch `MIDDLEWARE_CLASSES`.  However, Django 1.10 will ignore all `MIDDLEWARE_CLASSES` settings if `MIDDLEWARE` is also set, and complain about it.

Though I'd actually prefer to let user set such settings explicitly, for backward compatibility, I just made such logic aware of the new `MIDDLEWARE` var.