### PR TITLE
Improve exception handling in Serializer.transform

### DIFF
--- a/raven/utils/serializer/manager.py
+++ b/raven/utils/serializer/manager.py
@@ -64,12 +64,12 @@ class Serializer(object):
 
         try:
             for serializer in self.serializers:
-                if serializer.can(value):
-                    try:
+                try:
+                    if serializer.can(value):
                         return serializer.serialize(value, **kwargs)
-                    except Exception as e:
-                        logger.exception(e)
-                        return text_type(type(value))
+                except Exception as e:
+                    logger.exception(e)
+                    return text_type(type(value))
 
             # if all else fails, lets use the repr of the object
             try:


### PR DESCRIPTION
This is an additional fix for the case described in #862.

Same happens here: when `serializer.can()` triggers evaluation of the `value` of type `django.utils.functional.SimpleLazyObject` and the latter throws exception, the error isn't reported.
