### PR TITLE
Change django release path

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -28,7 +28,7 @@ Additional settings for the client are configured using the
         'dsn': '___DSN___',
         # If you are using git, you can also automatically configure the
         # release based on the git info.
-        'release': raven.fetch_git_sha(os.path.join(os.path.dirname(__file__), '..')),
+        'release': raven.fetch_git_sha(os.path.dirname(os.pardir)),
     }
 
 Once you've configured the client, you can test it using the standard Django

--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -28,7 +28,7 @@ Additional settings for the client are configured using the
         'dsn': '___DSN___',
         # If you are using git, you can also automatically configure the
         # release based on the git info.
-        'release': raven.fetch_git_sha(os.path.join(os.path.dirname(__file__), "..")),
+        'release': raven.fetch_git_sha(os.path.join(os.path.dirname(__file__), '..')),
     }
 
 Once you've configured the client, you can test it using the standard Django

--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -28,7 +28,7 @@ Additional settings for the client are configured using the
         'dsn': '___DSN___',
         # If you are using git, you can also automatically configure the
         # release based on the git info.
-        'release': raven.fetch_git_sha(os.path.dirname(__file__)),
+        'release': raven.fetch_git_sha(os.path.join(os.path.dirname(__file__), "..")),
     }
 
 Once you've configured the client, you can test it using the standard Django


### PR DESCRIPTION
Default path name gives error:
<img width="660" alt="screen shot 2016-10-18 at 12 57 13 pm" src="https://cloud.githubusercontent.com/assets/15368179/19494124/785a6e00-9532-11e6-8062-4dc9ee42a84a.png">

Changed the path so that it doesn't have this error. User might still have to configure their path differently (e.g. '../..').

@benvinegar 
