### PR TITLE
use deprecation MiddlewareMixin in SentryMiddleware ; should really fix #886

### DIFF
--- a/raven/contrib/django/middleware/__init__.py
+++ b/raven/contrib/django/middleware/__init__.py
@@ -78,7 +78,7 @@ class SentryResponseErrorIdMiddleware(MiddlewareMixin):
         return response
 
 
-class SentryMiddleware(MiddlewareMixin, threading.local):
+class SentryMiddleware(threading.local, MiddlewareMixin):
     resolver = RouteResolver()
 
     # backwards compat

--- a/raven/contrib/django/middleware/__init__.py
+++ b/raven/contrib/django/middleware/__init__.py
@@ -78,7 +78,7 @@ class SentryResponseErrorIdMiddleware(MiddlewareMixin):
         return response
 
 
-class SentryMiddleware(threading.local):
+class SentryMiddleware(MiddlewareMixin, threading.local):
     resolver = RouteResolver()
 
     # backwards compat


### PR DESCRIPTION
The problem was that Middleware interface changed in Django 1.10 and SentryMiddleware did not use that new interface.
