### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ cache:
 #  on:
 #    tags: true
 python:
-  - '2.6'
   - '2.7'
 #  - '3.2'
   - '3.3'
@@ -67,15 +66,5 @@ matrix:
 #      env: DJANGO=Django==1.7.11
     - python: '3.5'
       env: DJANGO=Django==1.8.7
-    - python: '2.6'
-      env: DJANGO="-e git+git://github.com/django/django.git#egg=Django"
     - python: '3.2'
       env: DJANGO="-e git+git://github.com/django/django.git#egg=Django"
-    - python: '2.6'
-      env: DJANGO=Django==1.10
-    - python: '2.6'
-      env: DJANGO=Django==1.9
-    - python: '2.6'
-      env: DJANGO=Django==1.8.7
-    - python: '2.6'
-      env: DJANGO=Django==1.7.11

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,7 +102,6 @@ discover:
    Supported Platforms
    -------------------
 
-   - Python 2.6
    - Python 2.7
    - Python 3.2
    - Python 3.3

--- a/docs/platform-support.rst
+++ b/docs/platform-support.rst
@@ -1,7 +1,6 @@
 Supported Platforms
 ===================
 
-- Python 2.6
 - Python 2.7
 - Python 3.2
 - Python 3.3

--- a/raven/contrib/bottle/utils.py
+++ b/raven/contrib/bottle/utils.py
@@ -21,7 +21,7 @@ def get_data_from_request(request):
     try:
         form_dict = request.forms.dict
         # we only are about the most recent one
-        formdata = dict([(k, form_dict[k][-1]) for k in form_dict])
+        formdata = {k: form_dict[k][-1] for k in form_dict}
     except Exception:
         formdata = {}
 

--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -39,7 +39,7 @@ def make_client(client_cls, app, dsn=None):
                 'dsn': dsn,
                 'include_paths': (
                     set(app.config.get('SENTRY_INCLUDE_PATHS', []))
-                    | set([app.import_name])
+                    | {app.import_name}
                 ),
                 # support legacy RAVEN_IGNORE_EXCEPTIONS
                 'ignore_exceptions': [

--- a/raven/transport/eventlet.py
+++ b/raven/transport/eventlet.py
@@ -7,8 +7,6 @@ raven.transport.eventlet
 """
 from __future__ import absolute_import
 
-import sys
-
 from raven.transport.http import HTTPTransport
 
 try:
@@ -36,11 +34,8 @@ class EventletHTTPTransport(HTTPTransport):
     def _send_payload(self, payload):
         req = eventlet_urllib2.Request(self._url, headers=payload[1])
         try:
-            if sys.version_info < (2, 6):
-                response = eventlet_urllib2.urlopen(req, payload[0]).read()
-            else:
-                response = eventlet_urllib2.urlopen(req, payload[0],
-                                                    self.timeout).read()
+            response = eventlet_urllib2.urlopen(req, payload[0],
+                                                self.timeout).read()
             return response
         except Exception as err:
             return err

--- a/raven/utils/http.py
+++ b/raven/utils/http.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 
 import socket
 import ssl
-import sys
 
 from raven.conf import defaults
 from raven.utils.compat import urllib2, httplib
@@ -56,11 +55,4 @@ def urlopen(url, data=None, timeout=defaults.TIMEOUT, ca_certs=None,
 
     opener = urllib2.build_opener(*handlers)
 
-    if sys.version_info < (2, 6):
-        default_timeout = socket.getdefaulttimeout()
-        socket.setdefaulttimeout(timeout)
-        try:
-            return opener.open(url, data)
-        finally:
-            socket.setdefaulttimeout(default_timeout)
     return opener.open(url, data, timeout)

--- a/raven/utils/testutils.py
+++ b/raven/utils/testutils.py
@@ -11,10 +11,7 @@ import raven
 
 from exam import Exam
 
-try:
-    from unittest2 import TestCase as BaseTestCase
-except ImportError:
-    from unittest import TestCase as BaseTestCase  # NOQA
+from unittest import TestCase as BaseTestCase
 
 
 class TestCase(Exam, BaseTestCase):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ install_requires = [
     'contextlib2',
 ]
 
-unittest2_requires = ['unittest2']
 flask_requires = [
     'Flask>=0.8',
     'blinker>=1.1',
@@ -53,9 +52,8 @@ webpy_tests_requires = [
     'web.py',
 ]
 
-# If it's python3, remove unittest2 & web.py
+# If it's python3, remove web.py
 if sys.version_info[0] == 3:
-    unittest2_requires = []
     webpy_tests_requires = []
 
     # If it's python3.2 or greater, don't use contextlib backport
@@ -84,7 +82,7 @@ tests_require = [
     'webtest',
     'anyjson',
 ] + (flask_requires + flask_tests_requires +
-     unittest2_requires + webpy_tests_requires)
+     webpy_tests_requires)
 
 
 class PyTest(TestCommand):
@@ -137,7 +135,6 @@ setup(
         'Intended Audience :: System Administrators',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -162,7 +162,6 @@ class DjangoClientTest(TestCase):
         assert event['level'] == logging.ERROR
         assert event['message'], "TypeError: int() argument must be a string or a number == not 'NoneType'"
 
-    @pytest.mark.skipif(sys.version_info[:2] == (2, 6), reason='Python 2.6')
     def test_view_exception(self):
         self.assertRaises(Exception, self.client.get, reverse('sentry-raise-exc'))
 
@@ -779,7 +778,7 @@ class SentryExceptionHandlerTest(TestCase):
     def test_does_exclude_filtered_types(self, exc_info, mock_send):
         exc_info.return_value = self.exc_info
         try:
-            self.client.ignore_exceptions = set(['ValueError'])
+            self.client.ignore_exceptions = {'ValueError'}
 
             self.handler.exception_handler(request=self.request)
         finally:
@@ -794,9 +793,9 @@ class SentryExceptionHandlerTest(TestCase):
 
         try:
             if six.PY3:
-                self.client.ignore_exceptions = set(['builtins.*'])
+                self.client.ignore_exceptions = {'builtins.*'}
             else:
-                self.client.ignore_exceptions = set(['exceptions.*'])
+                self.client.ignore_exceptions = {'exceptions.*'}
             self.handler.exception_handler(request=self.request)
         finally:
             self.client.ignore_exceptions.clear()
@@ -810,9 +809,9 @@ class SentryExceptionHandlerTest(TestCase):
 
         try:
             if six.PY3:
-                self.client.ignore_exceptions = set(['builtins.ValueError'])
+                self.client.ignore_exceptions = {'builtins.ValueError'}
             else:
-                self.client.ignore_exceptions = set(['exceptions.ValueError'])
+                self.client.ignore_exceptions = {'exceptions.ValueError'}
             self.handler.exception_handler(request=self.request)
         finally:
             self.client.ignore_exceptions.clear()

--- a/tests/contrib/flask/tests.py
+++ b/tests/contrib/flask/tests.py
@@ -259,13 +259,13 @@ class FlaskTest(BaseTest):
     def test_binds_default_include_paths(self):
         app = Flask(__name__)
         sentry = Sentry(app, dsn='http://public:secret@example.com/1')
-        assert sentry.client.include_paths == set([app.import_name])
+        assert sentry.client.include_paths == {app.import_name}
 
     def test_overrides_default_include_paths(self):
         app = Flask(__name__)
         app.config['SENTRY_CONFIG'] = {'include_paths': ['foo.bar']}
         sentry = Sentry(app, dsn='http://public:secret@example.com/1')
-        assert sentry.client.include_paths == set(['foo.bar'])
+        assert sentry.client.include_paths == {'foo.bar'}
 
 
 class FlaskLoginTest(BaseTest):

--- a/tests/handlers/logging/tests.py
+++ b/tests/handlers/logging/tests.py
@@ -54,7 +54,7 @@ class LoggingIntegrationTest(TestCase):
         class Foo(Exception):
             pass
         old = self.client.ignore_exceptions
-        self.client.ignore_exceptions = set(['Foo'])
+        self.client.ignore_exceptions = {'Foo'}
         try:
             try:
                 raise Foo()
@@ -278,8 +278,7 @@ class LoggingHandlerTest(TestCase):
 
     def test_logging_level_set(self):
         handler = SentryHandler('http://public:secret@example.com/1', level="ERROR")
-        # XXX: some version of python 2.6 seem to pass the string on instead of coercing it
-        self.assertTrue(handler.level in (logging.ERROR, 'ERROR'))
+        self.assertEqual(handler.level, logging.ERROR)
 
     def test_logging_level_not_set(self):
         handler = SentryHandler('http://public:secret@example.com/1')

--- a/tests/utils/json/tests.py
+++ b/tests/utils/json/tests.py
@@ -18,7 +18,7 @@ class JSONTest(TestCase):
         assert json.dumps(res) == '"2011-01-01T01:01:01Z"'
 
     def test_set(self):
-        res = set(['foo', 'bar'])
+        res = {'foo', 'bar'}
         assert json.dumps(res) in ('["foo", "bar"]', '["bar", "foo"]')
 
     def test_frozenset(self):

--- a/tests/versioning/tests.py
+++ b/tests/versioning/tests.py
@@ -14,22 +14,13 @@ def has_git_requirements():
     return os.path.exists(os.path.join(settings.PROJECT_ROOT, '.git', 'refs', 'heads', 'master'))
 
 
-# Python 2.6 does not contain subprocess.check_output
-def check_output(cmd, **kwargs):
-    return subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        **kwargs
-    ).communicate()[0]
-
-
 @pytest.mark.skipif('not has_git_requirements()')
 def test_fetch_git_sha():
     result = fetch_git_sha(settings.PROJECT_ROOT)
     assert result is not None
     assert len(result) == 40
     assert isinstance(result, six.string_types)
-    assert result == check_output(
+    assert result == subprocess.check_output(
         'git rev-parse --verify HEAD', shell=True, cwd=settings.PROJECT_ROOT
     ).decode('latin1').strip()
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, py35, pypy
+envlist = py27, py33, py34, py35, pypy
 
 [testenv]
 commands =


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.