### PR TITLE
Add settings var to allow customizing sentry middleware

### DIFF
--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -227,7 +227,7 @@ def install_middleware():
     This ensures things like request context and transaction names are made
     available.
     """
-    name = 'raven.contrib.django.middleware.SentryMiddleware'
+    name = getattr(settings, 'SENTRY_MIDDLEWARE', 'raven.contrib.django.middleware.SentryMiddleware')
     all_names = (name, 'raven.contrib.django.middleware.SentryLogMiddleware')
     with settings_lock:
         # default settings.MIDDLEWARE is None


### PR DESCRIPTION
We'd like the ability to override certain aspects of the middleware functionality without monkey-patching. Specifically, _get_transaction_from_request does not work well with some of our urls, so we want to have a fallback if nothing is resolved.