### PR TITLE
Merge logger tags

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Version 6.0.0
 * Strip whitespace from DSNs automatically.
 * Add `last_event_id` accessor to `Client`.
 * Do not require `sys.argv` to be available any more.
+* Tags defined on a logging handler will now be merged with individual log record's tags.
 
 Version 5.32.0
 --------------

--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -168,10 +168,10 @@ class SentryHandler(logging.Handler, object):
         data['level'] = record.levelno
         data['logger'] = record.name
 
-        if hasattr(record, 'tags'):
-            kwargs['tags'] = record.tags
-        elif self.tags:
-            kwargs['tags'] = self.tags
+        kwargs['tags'] = tags = {}
+        if self.tags:
+            tags.update(self.tags)
+        tags.update(getattr(record, 'tags', {}))
 
         kwargs.update(handler_kwargs)
 

--- a/tests/handlers/logging/tests.py
+++ b/tests/handlers/logging/tests.py
@@ -229,6 +229,15 @@ class LoggingIntegrationTest(TestCase):
         event = self.client.events.pop(0)
         assert event['tags'] == {'foo': 'bar'}
 
+    def test_tags_merge(self):
+        handler = SentryHandler(self.client, tags={'foo': 'bar', 'biz': 'baz'})
+        record = self.make_record('Message', extra={'tags': {'foo': 'faz'}})
+        handler.emit(record)
+
+        self.assertEqual(len(self.client.events), 1)
+        event = self.client.events.pop(0)
+        assert event['tags'] == {'foo': 'faz', 'biz': 'baz'}
+
     def test_fingerprint_on_event(self):
         record = self.make_record('Message', extra={'fingerprint': ['foo']})
         self.handler.emit(record)


### PR DESCRIPTION
When using both handler defined and logger defined tags, merge them allowing the handler to override the defaults.