### PR TITLE
Revert "Fix Django LOGGING example root logger"

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -82,6 +82,10 @@ ERROR and above messages to sentry, the following config can be used::
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': True,
+        'root': {
+            'level': 'WARNING',
+            'handlers': ['sentry'],
+        },
         'formatters': {
             'verbose': {
                 'format': '%(levelname)s %(asctime)s %(module)s '
@@ -101,10 +105,6 @@ ERROR and above messages to sentry, the following config can be used::
             }
         },
         'loggers': {
-            'root': {
-                'level': 'WARNING',
-                'handlers': ['sentry'],
-            },
             'django.db.backends': {
                 'level': 'ERROR',
                 'handlers': ['console'],


### PR DESCRIPTION
This reverts commit 5d863173772cb53edcf95c7ba83060ebeac90c38.

Like I elaborated at https://github.com/getsentry/raven-python/commit/5d863173772cb53edcf95c7ba83060ebeac90c38#commitcomment-19881817

In https://docs.python.org/library/logging.config.html#dictionary-schema-details,
there is in fact a special key named ``root`` in the ``LOGGING`` dict
that specifies the configuration for the root logger.
I think it can also be specified in the ``loggers`` dict, but then its key
should just be the empty string rather than ``root``!