### PR TITLE
In Django HTTP request data, multiple values for same key are lists

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -16,6 +16,8 @@ from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.http import HttpRequest
 from django.template import TemplateSyntaxError
+from django.utils.datastructures import MultiValueDict
+from django.utils import six
 
 try:
     # support Django 1.9
@@ -202,6 +204,11 @@ class DjangoClient(Client):
                         data = request.POST or '<unavailable>'
                     except Exception:
                         data = '<unavailable>'
+                    else:
+                        if isinstance(data, MultiValueDict):
+                            data = dict(
+                                (k, v[0] if len(v) == 1 else v)
+                                for k, v in six.iterlists(data))
         else:
             data = None
 


### PR DESCRIPTION
In a Django HttpRequest object, the request data is a QueryDict object, which is a dictionary-like class that supports multiple values for the same key. This is used, for instance, with `<select multiple>` form elements.

In order to have the request data serialize into JSON correctly when there are multiple values, it is necessary to use `QueryDict.iterlists()` / `QueryDict.lists()` (python 2 and 3, respectively). Otherwise, the value passed to Sentry will contain only the last value in the query string.