### PR TITLE
Do not record errors for terminals

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Version 6.0.0
 * Refactored transports to support multiple URLs.  This might affect
   you if you have custom subclasses of those.  The main change is that
   the URL parameter moved from the constructor into the `send` method.
+* Do not record from the sys except hook if stdin is a terminal.
 
 Version 5.32.0
 --------------

--- a/raven/base.py
+++ b/raven/base.py
@@ -242,14 +242,22 @@ class Client(object):
 
         self.logger.debug("Configuring Raven for host: {0}".format(self.remote))
 
-    def install_sys_hook(self):
+    def install_sys_hook(self, skip_for_tty=True):
         global __excepthook__
 
         if __excepthook__ is None:
             __excepthook__ = sys.excepthook
 
         def handle_exception(*exc_info):
-            self.captureException(exc_info=exc_info, level='fatal')
+            if not skip_for_tty:
+                capture = True
+            else:
+                try:
+                    capture = not sys.stdout.isatty()
+                except Exception:
+                    capture = True
+            if capture:
+                self.captureException(exc_info=exc_info, level='fatal')
             __excepthook__(*exc_info)
         handle_exception.raven_client = self
         sys.excepthook = handle_exception


### PR DESCRIPTION
This will not record errors by default if a tty is detected.  If you
want to record anyways do not register the default hook and manually
install it with the flag flipped.