### PR TITLE
Support release and environment tags for Zope

### DIFF
--- a/raven/contrib/zope/component.xml
+++ b/raven/contrib/zope/component.xml
@@ -19,5 +19,7 @@
     <key name="processors" required="no" datatype="string-list"/>
     <key name="project" required="no"/>
     <key name="dsn" required="no"/>
+    <key name="release" required="no"/>
+    <key name="environment" required="no"/>
   </sectiontype>
 </component>


### PR DESCRIPTION
In zope.conf's configuration spec, which will be passed on and processed by Raven.