### PR TITLE
Only print to stdout if stdout is connected to a tty(-like) device

### DIFF
--- a/raven/transport/threaded.py
+++ b/raven/transport/threaded.py
@@ -11,6 +11,7 @@ import atexit
 import logging
 import threading
 import os
+import sys
 
 from time import sleep, time
 
@@ -64,18 +65,20 @@ class AsyncWorker(object):
 
             if not self._timed_queue_join(initial_timeout):
                 # if that didn't work, wait a bit longer
-                # NB that size is an approximation, because other threads may
-                # add or remove items
-                size = self._queue.qsize()
 
-                print("Sentry is attempting to send %i pending error messages"
-                      % size)
-                print("Waiting up to %s seconds" % timeout)
+                if sys.stdout.isatty():
+                    # NB that size is an approximation, because other threads
+                    # may add or remove items
+                    size = self._queue.qsize()
 
-                if os.name == 'nt':
-                    print("Press Ctrl-Break to quit")
-                else:
-                    print("Press Ctrl-C to quit")
+                    print("Sentry is attempting to send %i "
+                          "pending error messages" % size)
+                    print("Waiting up to %s seconds" % timeout)
+
+                    if os.name == 'nt':
+                        print("Press Ctrl-Break to quit")
+                    else:
+                        print("Press Ctrl-C to quit")
 
                 self._timed_queue_join(timeout - initial_timeout)
 


### PR DESCRIPTION
We are running the raven python client inside of a (yes, very old school, I agree) CGI web application and would like to use a threaded transport, so that normal operation can continue while raven is working.

However, in rare but not rare enough cases, the CGI process is about to terminate before raven has sent all messages, and then, some output "Sentry is attempting to send... Hit Ctrl+C to abort" appears on stdout, which - lame old CGI - is the web page sent to the client. In worst case, the output is seen as (broken) HTTP headers, leading to interesting HTTP status codes from the web server.

To avoid the stdout output, as discussed in https://github.com/getsentry/raven-python/pull/932, I just added an isatty() check.

So: The overall diff is very small in fact, it's just that I had to change a bit of indent.