### PR TITLE
Handle ignore_exceptions values being class or string

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Version 6.0.0
   affected things like django-tastyepie.
 * Corrected an issue where Django's HTTP request was not always available
   within events.
+* Support both string and class values for ``ignore_exceptions`` parameters.
+  Class values also support child exceptions.
 
 Version 5.32.0
 --------------

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -168,7 +168,12 @@ The following are valid arguments which may be passed to the Raven client:
             'Http404',
             'django.exceptions.http.Http404',
             'django.exceptions.*',
+            ValueError,
         ]
+
+    Each item can be either a string or a class.
+    String declaration is strict (ie. does not works for child exceptions)
+    whereas class declaration handle inheritance (ie. child exceptions are also ignored).
 
 .. describe:: list_max_length
 

--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -42,10 +42,7 @@ def make_client(client_cls, app, dsn=None):
                     | set([app.import_name])
                 ),
                 # support legacy RAVEN_IGNORE_EXCEPTIONS
-                'ignore_exceptions': [
-                    '{0}.{1}'.format(x.__module__, x.__name__)
-                    for x in app.config.get('RAVEN_IGNORE_EXCEPTIONS', [])
-                ],
+                'ignore_exceptions': app.config.get('RAVEN_IGNORE_EXCEPTIONS', []),
                 'extra': {
                     'app': app,
                 },

--- a/tests/base/tests.py
+++ b/tests/base/tests.py
@@ -325,6 +325,45 @@ class ClientTest(TestCase):
         self.assertEquals(frame['filename'], 'tests/base/tests.py')
         self.assertEquals(frame['module'], __name__)
 
+    def test_exception_event_ignore_string(self):
+        class Foo(Exception):
+            pass
+
+        client = TempStoreClient(ignore_exceptions=['Foo'])
+        try:
+            raise Foo()
+        except Foo:
+            client.captureException()
+
+        self.assertEquals(len(client.events), 0)
+
+    def test_exception_event_ignore_class(self):
+        class Foo(Exception):
+            pass
+
+        client = TempStoreClient(ignore_exceptions=[Foo])
+        try:
+            raise Foo()
+        except Foo:
+            client.captureException()
+
+        self.assertEquals(len(client.events), 0)
+
+    def test_exception_event_ignore_child(self):
+        class Foo(Exception):
+            pass
+
+        class Bar(Foo):
+            pass
+
+        client = TempStoreClient(ignore_exceptions=[Foo])
+        try:
+            raise Bar()
+        except Bar:
+            client.captureException()
+
+        self.assertEquals(len(client.events), 0)
+
     def test_decorator_preserves_function(self):
         @self.client.capture_exceptions
         def test1():


### PR DESCRIPTION
This PR handle `ignore_exceptions` values being either string or class.
In the case of class, child exceptions are ignored too.

This both fixes #963 bringing back the existing flask behavior and allows all other integrations to take advantage of this behavior.