### PR TITLE
Always supply a user.ip_address value

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -143,6 +143,7 @@ class DjangoClient(Client):
         install_sql_hook()
 
     def get_user_info(self, request):
+
         user_info = {
             'ip_address': get_client_ip(request.META),
         }
@@ -159,8 +160,6 @@ class DjangoClient(Client):
                     authenticated = user.is_authenticated
                 if not authenticated:
                     return user_info
-
-            user_info = {}
 
             user_info['id'] = user.pk
 

--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -143,12 +143,15 @@ class Sentry(object):
         Requires Flask-Login (https://pypi.python.org/pypi/Flask-Login/)
         to be installed and setup.
         """
+        user_info = {}
+
         try:
-            user_info = {
-                'ip_address': request.access_route[0],
-            }
+            ip_address = request.access_route[0]
         except IndexError:
-            user_info = {}
+            ip_address = request.remote_addr
+
+        if ip_address:
+            user_info['ip_address'] = ip_address
 
         if not has_flask_login:
             return user_info

--- a/raven/utils/wsgi.py
+++ b/raven/utils/wsgi.py
@@ -92,3 +92,17 @@ def get_current_url(environ, root_only=False, strip_querystring=False,
             if qs:
                 cat('?' + qs)
     return ''.join(tmp)
+
+
+def get_client_ip(environ):
+    """
+    Naively yank the first IP address in an X-Forwarded-For header
+    and assume this is correct.
+
+    Note: Don't use this in security sensitive situations since this
+    value may be forged from a client.
+    """
+    try:
+        return environ['HTTP_X_FORWARDED_FOR'].split(',')[0].strip()
+    except (KeyError, IndexError):
+        return environ.get('REMOTE_ADDR')

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -231,7 +231,12 @@ class DjangoClientTest(TestCase):
 
             assert len(self.raven.events) == 1
             event = self.raven.events.pop(0)
-            assert 'user' not in event
+            assert 'user' in event
+
+            user_info = event['user']
+            assert user_info == {
+                {'ip_address': '127.0.0.1'}
+            }
 
             assert self.client.login(username='admin', password='password')
 
@@ -249,6 +254,7 @@ class DjangoClientTest(TestCase):
 
     @pytest.mark.skipif(not DJANGO_15, reason='< Django 1.5')
     def test_get_user_info_abstract_user(self):
+
         from django.db import models
         from django.http import HttpRequest
         from django.contrib.auth.models import AbstractBaseUser

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -250,6 +250,7 @@ class DjangoClientTest(TestCase):
     @pytest.mark.skipif(not DJANGO_15, reason='< Django 1.5')
     def test_get_user_info_abstract_user(self):
         from django.db import models
+        from django.http import HttpRequest
         from django.contrib.auth.models import AbstractBaseUser
 
         class MyUser(AbstractBaseUser):
@@ -263,8 +264,25 @@ class DjangoClientTest(TestCase):
             email='admin@example.com',
             id=1,
         )
-        user_info = self.raven.get_user_info(user)
+
+        request = HttpRequest()
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+        request.user = user
+        user_info = self.raven.get_user_info(request)
         assert user_info == {
+            'ip_address': '127.0.0.1',
+            'username': user.username,
+            'id': user.id,
+            'email': user.email,
+        }
+
+        request = HttpRequest()
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+        request.META['HTTP_X_FORWARDED_FOR'] = '1.1.1.1, 2.2.2.2'
+        request.user = user
+        user_info = self.raven.get_user_info(request)
+        assert user_info == {
+            'ip_address': '1.1.1.1',
             'username': user.username,
             'id': user.id,
             'email': user.email,
@@ -273,6 +291,7 @@ class DjangoClientTest(TestCase):
     @pytest.mark.skipif(not DJANGO_110, reason='< Django 1.10')
     def test_get_user_info_is_authenticated_property(self):
         from django.db import models
+        from django.http import HttpRequest
         from django.contrib.auth.models import AbstractBaseUser
 
         class MyUser(AbstractBaseUser):
@@ -289,8 +308,25 @@ class DjangoClientTest(TestCase):
             email='admin@example.com',
             id=1,
         )
-        user_info = self.raven.get_user_info(user)
+
+        request = HttpRequest()
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+        request.user = user
+        user_info = self.raven.get_user_info(request)
         assert user_info == {
+            'ip_address': '127.0.0.1',
+            'username': user.username,
+            'id': user.id,
+            'email': user.email,
+        }
+
+        request = HttpRequest()
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+        request.META['HTTP_X_FORWARDED_FOR'] = '1.1.1.1, 2.2.2.2'
+        request.user = user
+        user_info = self.raven.get_user_info(request)
+        assert user_info == {
+            'ip_address': '1.1.1.1',
             'username': user.username,
             'id': user.id,
             'email': user.email,

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -234,9 +234,7 @@ class DjangoClientTest(TestCase):
             assert 'user' in event
 
             user_info = event['user']
-            assert user_info == {
-                {'ip_address': '127.0.0.1'}
-            }
+            assert user_info == {'ip_address': '127.0.0.1'}
 
             assert self.client.login(username='admin', password='password')
 
@@ -247,6 +245,7 @@ class DjangoClientTest(TestCase):
             assert 'user' in event
             user_info = event['user']
             assert user_info == {
+                'ip_address': '127.0.0.1',
                 'username': self.user.username,
                 'id': self.user.id,
                 'email': self.user.email,

--- a/tests/contrib/flask/tests.py
+++ b/tests/contrib/flask/tests.py
@@ -313,7 +313,7 @@ class FlaskLoginTest(BaseTest):
 
     def test_user(self):
         self.client.get('/login/')
-        self.client.get('/an-error/')
+        self.client.get('/an-error/', environ_overrides={'REMOTE_ADDR': '127.0.0.1'})
         event = self.raven.events.pop(0)
         assert event['message'] == 'ValueError: hello world'
         assert 'request' in event

--- a/tests/contrib/flask/tests.py
+++ b/tests/contrib/flask/tests.py
@@ -59,7 +59,7 @@ def create_app(ignore_exceptions=None, debug=False, **config):
     def capture_exception():
         try:
             raise ValueError('Boom')
-        except:
+        except Exception:
             current_app.extensions['sentry'].captureException()
         return 'Hello'
 
@@ -318,4 +318,4 @@ class FlaskLoginTest(BaseTest):
         assert event['message'] == 'ValueError: hello world'
         assert 'request' in event
         assert 'user' in event
-        self.assertDictEqual(event['user'], User().to_dict())
+        self.assertDictEqual(event['user'], dict({'ip_address': '127.0.0.1'}, **User().to_dict()))

--- a/tests/utils/wsgi/tests.py
+++ b/tests/utils/wsgi/tests.py
@@ -1,5 +1,5 @@
 from raven.utils.testutils import TestCase
-from raven.utils.wsgi import get_headers, get_host, get_environ
+from raven.utils.wsgi import get_headers, get_host, get_environ, get_client_ip
 
 
 class GetHeadersTest(TestCase):
@@ -84,3 +84,13 @@ class GetHostTest(TestCase):
             'SERVER_PORT': '81',
         })
         self.assertEquals(result, 'example.com:81')
+
+
+class GetClientIpTest(TestCase):
+    def test_has_remote_addr(self):
+        result = get_client_ip({'REMOTE_ADDR': '127.0.0.1'})
+        self.assertEquals(result, '127.0.0.1')
+
+    def test_xff(self):
+        result = get_client_ip({'HTTP_X_FORWARDED_FOR': '1.1.1.1, 127.0.0.1'})
+        self.assertEquals(result, '1.1.1.1')


### PR DESCRIPTION
When applicable, we should try and pass along the X-Forwarded-For
value from the client as REMOTE_ADDR. There is no security implications
here and only yields more accurate data in Sentry itself. It's not as
common for a user to mutate their own REMOTE_ADDR, so we should try to
do the right thing and fetch XFF when present instead.

It's an explicitly decision to mutate REMOTE_ADDR inside of the `env`
rather than the `user` interface because right now, the Sentry server is
taking the liberty of filling in the user.ip_address from the
env.REMOTE_ADDR already when it exists, so it only makes sense to just
pass along the more expected behavior.

This has come up a number of times in support and from users.