### PR TITLE
Import "reload" for gevent transport tests

### DIFF
--- a/tests/transport/gevent/tests.py
+++ b/tests/transport/gevent/tests.py
@@ -5,6 +5,11 @@ import time
 import socket
 import gevent.monkey
 
+try:
+    from importlib import reload
+except ImportError:
+    from imp import reload
+
 from raven.utils.testutils import TestCase
 from raven.base import Client
 from raven.transport.gevent import GeventedHTTPTransport


### PR DESCRIPTION
In Python 2, `reload()` is a builtin. This is not the case for Python 3. It should be imported from `importlib` or `imp`. Try both. This also works with Python 2, so no special test case.