### PR TITLE
allow stacktrace with no frames

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -641,7 +641,7 @@ class Client(object):
             for frame in data['stacktrace']['frames']:
                 yield frame
         if 'exception' in data:
-            for frame in data['exception']['values'][-1]['stacktrace']['frames']:
+            for frame in data['exception']['values'][-1]['stacktrace'].get('frames', []):
                 yield frame
 
     def _successful_send(self):
@@ -675,7 +675,7 @@ class Client(object):
         output = [message]
         if 'exception' in data and 'stacktrace' in data['exception']['values'][-1]:
             # try to reconstruct a reasonable version of the exception
-            for frame in data['exception']['values'][-1]['stacktrace']['frames']:
+            for frame in data['exception']['values'][-1]['stacktrace'].get('frames', []):
                 output.append('  File "%(fn)s", line %(lineno)s, in %(func)s' % {
                     'fn': frame.get('filename', 'unknown_filename'),
                     'lineno': frame.get('lineno', -1),


### PR DESCRIPTION
I am running into a KeyError: missing frames when I fail to submit to sentry from my custom client which uses raven-python.

This pulls request make it work when a frames list does not exist under the stacktrace directory.

> 19:39:21 worker.1      |   File "/projects/crashzone/src/crashzone/sentry_send.py", line 14, in send
> 19:39:21 worker.1      |     client.send_encoded(msg)
> 19:39:21 worker.1      |   File "/projects/crashzone/venv/lib/python2.7/site-packages/raven/base.py", line 735, in send_encoded
> 19:39:21 worker.1      |     **kwargs
> 19:39:21 worker.1      |   File "/projects/crashzone/venv/lib/python2.7/site-packages/raven/base.py", line 697, in send_remote
> 19:39:21 worker.1      |     failed_send(e)
> 19:39:21 worker.1      |   File "/projects/crashzone/venv/lib/python2.7/site-packages/raven/base.py", line 684, in failed_send
> 19:39:21 worker.1      |     self._failed_send(e, url, self.decode(data))
> 19:39:21 worker.1      |   File "/projects/crashzone/venv/lib/python2.7/site-packages/raven/base.py", line 648, in _failed_send
> 19:39:21 worker.1      |     self._log_failed_submission(data)
> 19:39:21 worker.1      |   File "/projects/crashzone/venv/lib/python2.7/site-packages/raven/base.py", line 660, in _log_failed_submission
> 19:39:21 worker.1      |     for frame in data['exception']['values'][-1]['stacktrace']['frames']:
> 19:39:21 worker.1      | KeyError: 'frames'
> 