### PR TITLE
No longer provide form data for Flask. Fixes #457

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Version 6.1.0
+-------------
+
+* No longer provide form data for Flask (#457)
+
 Version 6.0.0
 -------------
 

--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -19,7 +19,6 @@ import logging
 
 from flask import request, current_app, g
 from flask.signals import got_request_exception, request_finished
-from werkzeug.exceptions import ClientDisconnected
 
 from raven.conf import setup_logging
 from raven.base import Client
@@ -176,40 +175,12 @@ class Sentry(object):
         """
         Determine how to retrieve actual data by using request.mimetype.
         """
-        if self.is_json_type(request.mimetype):
-            retriever = self.get_json_data
-        else:
-            retriever = self.get_form_data
-        return self.get_http_info_with_retriever(request, retriever)
-
-    def is_json_type(self, content_type):
-        return content_type == 'application/json'
-
-    def get_form_data(self, request):
-        return request.form
-
-    def get_json_data(self, request):
-        return request.data
-
-    def get_http_info_with_retriever(self, request, retriever=None):
-        """
-        Exact method for getting http_info but with form data work around.
-        """
-        if retriever is None:
-            retriever = self.get_form_data
-
         urlparts = urlparse.urlsplit(request.url)
-
-        try:
-            data = retriever(request)
-        except ClientDisconnected:
-            data = {}
 
         return {
             'url': '%s://%s%s' % (urlparts.scheme, urlparts.netloc, urlparts.path),
             'query_string': urlparts.query,
             'method': request.method,
-            'data': data,
             'headers': dict(get_headers(request.environ)),
             'env': dict(get_environ(request.environ)),
         }

--- a/tests/contrib/flask/tests.py
+++ b/tests/contrib/flask/tests.py
@@ -130,7 +130,6 @@ class FlaskTest(BaseTest):
         self.assertEquals(http['url'], 'http://localhost/an-error/')
         self.assertEquals(http['query_string'], 'foo=bar')
         self.assertEquals(http['method'], 'GET')
-        self.assertEquals(http['data'], {})
         self.assertTrue('headers' in http)
         headers = http['headers']
         self.assertTrue('Content-Length' in headers, headers.keys())
@@ -157,7 +156,6 @@ class FlaskTest(BaseTest):
         self.assertEquals(http['url'], 'http://localhost/an-error/')
         self.assertEquals(http['query_string'], 'biz=baz')
         self.assertEquals(http['method'], 'POST')
-        self.assertEquals(http['data'], {'foo': 'bar'})
         self.assertTrue('headers' in http)
         headers = http['headers']
         self.assertTrue('Content-Length' in headers, headers.keys())
@@ -205,7 +203,6 @@ class FlaskTest(BaseTest):
 
         assert 'request' in event
         http = event['request']
-        self.assertEqual({}, http.get('data'))
 
     def test_wrap_wsgi_status(self):
         _, _, app_debug = self.make_client_and_raven(debug=True)


### PR DESCRIPTION
I think this feature does not make much sense, particularly because we badly
trim down the form data on the server anyways for security and size reasons.