### PR TITLE
Add provision to sample per message

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -566,7 +566,8 @@ class Client(object):
         })
 
     def capture(self, event_type, data=None, date=None, time_spent=None,
-                extra=None, stack=None, tags=None, **kwargs):
+                extra=None, stack=None, tags=None, sample_rate=None,
+                **kwargs):
         """
         Captures and processes an event and pipes it off to SentryClient.send.
 
@@ -636,11 +637,8 @@ class Client(object):
             **kwargs)
 
         # should this event be sampled?
-        sample_rate = self.sample_rate
-        try:
-            sample_rate = float(extra['sample_rate'])
-        except (TypeError, KeyError, ValueError):
-            pass
+        if sample_rate is None:
+            sample_rate = self.sample_rate
 
         if self._random.random() < sample_rate:
             self.send(**data)

--- a/raven/base.py
+++ b/raven/base.py
@@ -636,7 +636,13 @@ class Client(object):
             **kwargs)
 
         # should this event be sampled?
-        if self._random.random() < self.sample_rate:
+        sample_rate = self.sample_rate
+        try:
+            sample_rate = float(extra['sample_rate'])
+        except (TypeError, KeyError, ValueError):
+            pass
+
+        if self._random.random() < sample_rate:
             self.send(**data)
 
         self._local_state.last_event_id = data['event_id']

--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -174,7 +174,14 @@ class SentryHandler(logging.Handler, object):
         tags.update(getattr(record, 'tags', {}))
 
         kwargs.update(handler_kwargs)
+        sample_rate = extra.pop('sample_rate', None)
+        try:
+            if sample_rate is not None:
+                sample_rate = float(sample_rate)
+        except ValueError:
+            sample_rate = None
 
         return self.client.capture(
             event_type, stack=stack, data=data,
-            extra=extra, date=date, **kwargs)
+            extra=extra, date=date, sample_rate=sample_rate,
+            **kwargs)

--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -175,11 +175,6 @@ class SentryHandler(logging.Handler, object):
 
         kwargs.update(handler_kwargs)
         sample_rate = extra.pop('sample_rate', None)
-        try:
-            if sample_rate is not None:
-                sample_rate = float(sample_rate)
-        except ValueError:
-            sample_rate = None
 
         return self.client.capture(
             event_type, stack=stack, data=data,

--- a/tests/base/tests.py
+++ b/tests/base/tests.py
@@ -557,36 +557,12 @@ class ClientTest(TestCase):
         self.assertEquals(len(self.client.events), 0)
 
     def test_sample_rate_per_message(self):
-        self.client.extra = {
-            'foo': 'bar',
-        }
         self.client.sample_rate = 1
-        self.client.captureMessage(message='test', extra={'sample_rate': 0.0})
+        self.client.captureMessage(message='test', sample_rate=0.0)
         self.assertEquals(len(self.client.events), 0)
 
         self.client.sample_rate = 0
-        self.client.captureMessage(message='test', extra={'sample_rate': 1.0})
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)
-        if not PY2:
-            expected = {'sample_rate': 1.0, 'foo': "'bar'"}
-        else:
-            expected = {'sample_rate': 1.0, 'foo': "u'bar'"}
-        self.assertEquals(event['extra'], expected)
-
-    def test_sample_rate_per_message_is_resilient_to_bad_values(self):
-        self.client.sample_rate = 0
-
-        # sample_rate is not a number
-        self.client.captureMessage(message='test', extra={'sample_rate': 'foo'})
-        self.assertEquals(len(self.client.events), 0)
-
-        # sample_rate is not present
-        self.client.captureMessage(message='test', extra={'foo': '1.0'})
-        self.assertEquals(len(self.client.events), 0)
-
-        # sample_rate can be cast into a float
-        self.client.captureMessage(message='test', extra={'sample_rate': '1.0'})
+        self.client.captureMessage(message='test', sample_rate=1.0)
         self.assertEquals(len(self.client.events), 1)
 
     def test_transport_registration(self):

--- a/tests/base/tests.py
+++ b/tests/base/tests.py
@@ -551,6 +551,44 @@ class ClientTest(TestCase):
             expected = {'logger': "u'test'", 'foo': "u'bar'"}
         self.assertEquals(event['extra'], expected)
 
+    def test_sample_rate(self):
+        self.client.sample_rate = 0.0
+        self.client.captureMessage(message='test')
+        self.assertEquals(len(self.client.events), 0)
+
+    def test_sample_rate_per_message(self):
+        self.client.extra = {
+            'foo': 'bar',
+        }
+        self.client.sample_rate = 1
+        self.client.captureMessage(message='test', extra={'sample_rate': 0.0})
+        self.assertEquals(len(self.client.events), 0)
+
+        self.client.sample_rate = 0
+        self.client.captureMessage(message='test', extra={'sample_rate': 1.0})
+        self.assertEquals(len(self.client.events), 1)
+        event = self.client.events.pop(0)
+        if not PY2:
+            expected = {'sample_rate': 1.0, 'foo': "'bar'"}
+        else:
+            expected = {'sample_rate': 1.0, 'foo': "u'bar'"}
+        self.assertEquals(event['extra'], expected)
+
+    def test_sample_rate_per_message_is_resilient_to_bad_values(self):
+        self.client.sample_rate = 0
+
+        # sample_rate is not a number
+        self.client.captureMessage(message='test', extra={'sample_rate': 'foo'})
+        self.assertEquals(len(self.client.events), 0)
+
+        # sample_rate is not present
+        self.client.captureMessage(message='test', extra={'foo': '1.0'})
+        self.assertEquals(len(self.client.events), 0)
+
+        # sample_rate can be cast into a float
+        self.client.captureMessage(message='test', extra={'sample_rate': '1.0'})
+        self.assertEquals(len(self.client.events), 1)
+
     def test_transport_registration(self):
         client = Client('http://public:secret@example.com/1',
                         transport=HTTPTransport)

--- a/tests/handlers/logging/tests.py
+++ b/tests/handlers/logging/tests.py
@@ -262,6 +262,23 @@ class LoggingIntegrationTest(TestCase):
         event = self.client.events.pop(0)
         assert event['server_name'] == 'foo'
 
+    def test_sample_rate(self):
+        record = self.make_record('Message', extra={'sample_rate': 0.0})
+        self.handler.emit(record)
+
+        self.assertEqual(len(self.client.events), 0)
+
+        record = self.make_record('Message', extra={'sample_rate': 1.0})
+        self.handler.emit(record)
+
+        self.assertEqual(len(self.client.events), 1)
+
+    def test_sample_rate_bad_values(self):
+        record = self.make_record('Message', extra={'sample_rate': 'foo'})
+        self.handler.emit(record)
+
+        self.assertEqual(len(self.client.events), 1)
+
 
 class LoggingHandlerTest(TestCase):
     def test_client_arg(self):

--- a/tests/handlers/logging/tests.py
+++ b/tests/handlers/logging/tests.py
@@ -273,12 +273,6 @@ class LoggingIntegrationTest(TestCase):
 
         self.assertEqual(len(self.client.events), 1)
 
-    def test_sample_rate_bad_values(self):
-        record = self.make_record('Message', extra={'sample_rate': 'foo'})
-        self.handler.emit(record)
-
-        self.assertEqual(len(self.client.events), 1)
-
 
 class LoggingHandlerTest(TestCase):
     def test_client_arg(self):


### PR DESCRIPTION
- Add sample_rate to Client.capture that overrides Client.sample_rate
- Add logic in SentryHandler to look for `sample_rate` in `extra` extracted from the `LogRecord` and pass that to `capture`

Usage: 

```python
some_logger.warning('foo', extra={'sample_rate': 0.5}  # sample 50% of the events

# or

client.captureMessage('Something went fundamentally wrong', sample_rate=0.5)
```

Hi! Would this be something you'd consider adding? If so, I can go ahead and add some docs. If not, is there a variation of this that you'd consider? This could be an alternative (or rather supplementary to client-level sample rate approach) to tackle https://github.com/getsentry/raven-python/issues/323)