### PR TITLE
Add processor that sanitizes configurable keys

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -186,6 +186,7 @@ class Client(object):
         self.site = o.get('site')
         self.include_versions = o.get('include_versions', True)
         self.processors = o.get('processors')
+        self.sanitize_keys = o.get('sanitize_keys')
         if self.processors is None:
             self.processors = defaults.PROCESSORS
 

--- a/raven/processors.py
+++ b/raven/processors.py
@@ -68,8 +68,7 @@ class RemoveStackLocalsProcessor(Processor):
 
 class SanitizeKeysProcessor(Processor):
     """
-    Asterisk out things that look like passwords, credit card numbers,
-    and API keys in frames, http, and basic extra data.
+    Asterisk out things that correspond to a configurable set of keys.
     """
     MASK = '*' * 8
 
@@ -144,6 +143,10 @@ class SanitizeKeysProcessor(Processor):
 
 
 class SanitizePasswordsProcessor(SanitizeKeysProcessor):
+    """
+    Asterisk out things that look like passwords, credit card numbers,
+    and API keys in frames, http, and basic extra data.
+    """
     FIELDS = frozenset([
         'password',
         'secret',

--- a/raven/utils/conf.py
+++ b/raven/utils/conf.py
@@ -46,6 +46,7 @@ def convert_options(settings, defaults=None):
     options.setdefault('list_max_length', getopt('list_max_length'))
     options.setdefault('site', getopt('site'))
     options.setdefault('processors', getopt('processors'))
+    options.setdefault('sanitize_keys', getopt('sanitize_keys'))
     options.setdefault('dsn', getopt('dsn', os.environ.get('SENTRY_DSN')))
     options.setdefault('context', getopt('context'))
     options.setdefault('tags', getopt('tags'))


### PR DESCRIPTION
The logic of the new processor is almost identical to the logic of the
existing SanitizePasswordsProcessor, so this commit also changes the
implementation of SanitizePasswordsProcessor to avoid code-duplication.
It now inherits from the new SanitizeKeysProcessor.