### PR TITLE
Specify in which version of 2.7 was extra keyword added to .exception

### DIFF
--- a/docs/integrations/logging.rst
+++ b/docs/integrations/logging.rst
@@ -92,7 +92,7 @@ Sentry to render it based on that information::
    not be an acceptable keyword argument for a logger's ``.exception()``
    method (``.debug()``, ``.info()``, ``.warning()``, ``.error()`` and
    ``.critical()`` should work fine regardless of Python version). This
-   should be fixed as of Python 3.2. Official issue here:
+   should be fixed as of Python 2.7.4 and 3.2. Official issue here:
    http://bugs.python.org/issue15541.
 
 While we don't recommend this, you can also enable implicit stack


### PR DESCRIPTION
See tags in the commit: https://github.com/python/cpython/commit/947f358a069c9141c0230e440ab5cba07df0f87f