### PR TITLE
Ensure consistent fingerprint for SoftTimeLimitExceeded exceptions

### DIFF
--- a/raven/contrib/celery/__init__.py
+++ b/raven/contrib/celery/__init__.py
@@ -73,7 +73,7 @@ class SentryCeleryHandler(object):
 
         # This signal is fired inside the stack so let raven do its magic
         if isinstance(einfo.exception, SoftTimeLimitExceeded):
-            fingerprint = ['celery', 'SoftTimeLimitExceeded', sender]
+            fingerprint = ['celery', 'SoftTimeLimitExceeded', getattr(sender, 'name', sender)]
         else:
             fingerprint = None
 


### PR DESCRIPTION
I've been finding that ``SoftTimeLimitExceeded`` exceptions have not been grouped in the Sentry UI as I would have expected. I believe I have traced it down to the line changed in this pull request. They seemed to occasionally stop form new groups for non-obvious reasons.

After looking around, it seems that ``sender`` (presumably a task instance) includes an object ID in its string representation. As a result, the fingerprint would be different for every celery worker process.

This change will attempt to use the full task name (i.e. ``"my.app.tasks.do_it"``) before falling back to the original implementation.