### PR TITLE
Added support for logging integration via ZConfig:

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -24,5 +24,6 @@ client.
    rq
    tornado
    wsgi
+   zconfig
    zerorpc
    zope

--- a/docs/integrations/zconfig.rst
+++ b/docs/integrations/zconfig.rst
@@ -3,8 +3,9 @@ ZConfig logging configuration
 
 `ZConfig
 <http://zconfig.readthedocs.io/en/latest/using-logging.html>`_
-provides one of the most powerful clean configuration mechanism for
-the Python logging module.  To learn more, see:
+provides a configuration mechanism for the Python logging module.
+
+To learn more, see:
 
   http://zconfig.readthedocs.io/en/latest/using-logging.html
 

--- a/docs/integrations/zconfig.rst
+++ b/docs/integrations/zconfig.rst
@@ -1,0 +1,32 @@
+ZConfig logging configuration
+=============================
+
+`ZConfig
+<http://zconfig.readthedocs.io/en/latest/using-logging.html>`_
+provides one of the most powerful clean configuration mechanism for
+the Python logging module.  To learn more, see:
+
+  http://zconfig.readthedocs.io/en/latest/using-logging.html
+
+To use with sentry, use the sentry handler tag:
+
+.. code-block:: xml
+
+  <logger>
+    level INFO
+    <logfile>
+     path ${buildout:directory}/var/{:_buildout_section_name_}.log
+     level INFO
+    </logfile>
+
+    %import raven.contrib.zconfig
+    <sentry>
+      dsn ___DSN___
+      level ERROR
+    </sentry>
+  </logger>
+
+This configuration retains normal logging to a logfile, but adds
+Sentry logging for ERRORs.
+
+All options of :py:class:`raven.base.Client` are supported.

--- a/raven/contrib/zconfig/__init__.py
+++ b/raven/contrib/zconfig/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""
+raven.contrib.zope
+~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+import ZConfig.components.logger.factory
+import raven.handlers.logging
+
+class Factory(ZConfig.components.logger.factory.Factory):
+
+    def getLevel(self):
+        return self.section.level
+
+    def create(self):
+        return raven.handlers.logging.SentryHandler(**self.section.__dict__)
+
+    def __init__(self, section):
+        ZConfig.components.logger.factory.Factory.__init__(self)
+        self.section = section

--- a/raven/contrib/zconfig/__init__.py
+++ b/raven/contrib/zconfig/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 """
 raven.contrib.zconfig
 ~~~~~~~~~~~~~~~~~~~~~

--- a/raven/contrib/zconfig/__init__.py
+++ b/raven/contrib/zconfig/__init__.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 """
-raven.contrib.zope
-~~~~~~~~~~~~~~~~~~
+raven.contrib.zconfig
+~~~~~~~~~~~~~~~~~~~~~
 
 :copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 import ZConfig.components.logger.factory
 import raven.handlers.logging
+
 
 class Factory(ZConfig.components.logger.factory.Factory):
 

--- a/raven/contrib/zconfig/__init__.py
+++ b/raven/contrib/zconfig/__init__.py
@@ -7,18 +7,33 @@ raven.contrib.zconfig
 :copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
+import logging
 import ZConfig.components.logger.factory
 import raven.handlers.logging
 
 
 class Factory(ZConfig.components.logger.factory.Factory):
 
+    def __init__(self, section):
+        ZConfig.components.logger.factory.Factory.__init__(self)
+        self.section = section
+        self.section.level = self.section.level or logging.ERROR
+
     def getLevel(self):
         return self.section.level
 
     def create(self):
-        return raven.handlers.logging.SentryHandler(**self.section.__dict__)
-
-    def __init__(self, section):
-        ZConfig.components.logger.factory.Factory.__init__(self)
-        self.section = section
+        return raven.handlers.logging.SentryHandler(
+            dsn=self.section.dsn,
+            site=self.section.site,
+            name=self.section.name,
+            release=self.section.release,
+            environment=self.section.environment,
+            exclude_paths=self.section.exclude_paths,
+            include_paths=self.section.include_paths,
+            sample_rate=self.section.sample_rate,
+            list_max_length=self.section.list_max_length,
+            string_max_length=self.section.string_max_length,
+            auto_log_stacks=self.section.auto_log_stacks,
+            processors=self.section.processors,
+            level=self.section.level)

--- a/raven/contrib/zconfig/component.xml
+++ b/raven/contrib/zconfig/component.xml
@@ -8,18 +8,17 @@
                datatype="raven.contrib.zconfig.Factory"
                implements="ZConfig.logger.handler"
                extends="ZConfig.logger.base-log-handler">
-    <key name="include_paths" required="no" datatype="string-list"/>
-    <key name="exclude_paths" required="no" datatype="string-list"/>
-    <key name="timeout" required="no" datatype="integer"/>
-    <key name="name" required="no"/>
-    <key name="auto_log_stacks" required="no" datatype="boolean"/>
-    <key name="string_max_length" required="no" datatype="integer"/>
-    <key name="list_max_length" required="no" datatype="integer"/>
-    <key name="site" required="no"/>
-    <key name="processors" required="no" datatype="string-list"/>
-    <key name="project" required="no"/>
     <key name="dsn" required="no"/>
+    <key name="site" required="no"/>
+    <key name="name" required="no"/>
     <key name="release" required="no"/>
     <key name="environment" required="no"/>
+    <key name="exclude_paths" required="no" datatype="string-list"/>
+    <key name="include_paths" required="no" datatype="string-list"/>
+    <key name="sample_rate" required="no" datatype="float" default="1.0" />
+    <key name="list_max_length" required="no" datatype="integer"/>
+    <key name="string_max_length" required="no" datatype="integer"/>
+    <key name="auto_log_stacks" required="no" datatype="boolean"/>
+    <key name="processors" required="no" datatype="string-list"/>
   </sectiontype>
 </component>

--- a/raven/contrib/zconfig/component.xml
+++ b/raven/contrib/zconfig/component.xml
@@ -1,0 +1,25 @@
+<component>
+  <description>
+  </description>
+
+  <import package="ZConfig.components.logger" file="abstract.xml"/>
+
+  <sectiontype name="sentry"
+               datatype="raven.contrib.zconfig.Factory"
+               implements="ZConfig.logger.handler"
+               extends="ZConfig.logger.base-log-handler">
+    <key name="include_paths" required="no" datatype="string-list"/>
+    <key name="exclude_paths" required="no" datatype="string-list"/>
+    <key name="timeout" required="no" datatype="integer"/>
+    <key name="name" required="no"/>
+    <key name="auto_log_stacks" required="no" datatype="boolean"/>
+    <key name="string_max_length" required="no" datatype="integer"/>
+    <key name="list_max_length" required="no" datatype="integer"/>
+    <key name="site" required="no"/>
+    <key name="processors" required="no" datatype="string-list"/>
+    <key name="project" required="no"/>
+    <key name="dsn" required="no"/>
+    <key name="release" required="no"/>
+    <key name="environment" required="no"/>
+  </sectiontype>
+</component>

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ tests_require = [
     'webob',
     'webtest',
     'anyjson',
+    'ZConfig',
 ] + (
     flask_requires + flask_tests_requires +
     unittest2_requires + webpy_tests_requires

--- a/tests/contrib/zconfig/tests.py
+++ b/tests/contrib/zconfig/tests.py
@@ -1,0 +1,76 @@
+from __future__ import absolute_import
+import logging
+import mock
+import unittest
+from ZConfig import configureLoggers
+
+
+class TestConfig(unittest.TestCase):
+
+    @mock.patch("raven.handlers.logging.Client")
+    def test_minimal(self, Client):
+        configureLoggers("""
+        <logger>
+          %import raven.contrib.zconfig
+          <sentry>
+            dsn https://abc:def@example.com/42
+          </sentry>
+        </logger>
+        """)
+        handler = logging.getLogger().handlers[-1]
+        logging.getLogger().handlers.remove(handler)
+        self.assertEqual(handler.level, logging.ERROR)
+        Client.assert_called_with(
+            dsn='https://abc:def@example.com/42',
+            site=None,
+            name=None,
+            release=None,
+            environment=None,
+            exclude_paths=None,
+            include_paths=None,
+            sample_rate=1.0,
+            list_max_length=None,
+            string_max_length=None,
+            auto_log_stacks=None,
+            processors=None,
+            level=logging.ERROR)
+
+    @mock.patch("raven.handlers.logging.Client")
+    def test_many(self, Client):
+        configureLoggers("""
+        <logger>
+          %import raven.contrib.zconfig
+          <sentry>
+            level WARNING
+            dsn https://abc:def@example.com/42
+            site test-site
+            name test
+            release 42.0
+            environment testing
+            exclude_paths /a /b
+            include_paths /c /d
+            sample_rate 0.5
+            list_max_length 9
+            string_max_length 99
+            auto_log_stacks true
+            processors x y z
+          </sentry>
+        </logger>
+        """)
+        handler = logging.getLogger().handlers[-1]
+        logging.getLogger().handlers.remove(handler)
+        self.assertEqual(handler.level, logging.WARNING)
+        Client.assert_called_with(
+            dsn='https://abc:def@example.com/42',
+            site='test-site',
+            name='test',
+            release='42.0',
+            environment='testing',
+            exclude_paths=['/a', '/b'],
+            include_paths=['/c', '/d'],
+            sample_rate=0.5,
+            list_max_length=9,
+            string_max_length=99,
+            auto_log_stacks=True,
+            processors=['x', 'y', 'z'],
+            level=logging.WARNING)


### PR DESCRIPTION
See: http://zconfig.readthedocs.io/en/latest/using-logging.html

Note that the Zope integration also uses ZConfig, but adds lots of Zope-specific machinery that won't work elsewhere.  This integration cribbed from the Zope integration. :)