### PR TITLE
Default `get_public_dsn()` to https 

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -57,15 +57,13 @@ Inside your template, you can now use:
 
 .. sourcecode:: html+django
 
-    <script>Raven.config('{% sentry_public_dsn %}').install()</script>
+    <body data-sentry="{% sentry_public_dsn %}">
 
-By default, the DSN is generated in a protocol relative fashion, e.g.
-``//public@example.com/1``. If you need a specific protocol, you can
-override:
+Inside your javascript:
 
-.. sourcecode:: html+django
+.. sourcecode:: js
 
-    {% sentry_public_dsn 'https' %}
+    Raven.config(document.body.dataset.sentry).install();
 
 .. sentry:edition:: hosted, on-premise
 

--- a/docs/integrations/flask.rst
+++ b/docs/integrations/flask.rst
@@ -161,7 +161,7 @@ crash dialog:
     def internal_server_error(error):
         return render_template('500.html',
             event_id=g.sentry_event_id,
-            public_dsn=sentry.client.get_public_dsn('https')
+            public_dsn=sentry.client.get_public_dsn()
         )
 
 And in the error template (``500.html``) you can then do this:

--- a/raven/base.py
+++ b/raven/base.py
@@ -322,22 +322,15 @@ class Client(object):
     def get_handler(self, name):
         return self.module_cache[name](self)
 
-    def get_public_dsn(self, scheme=None):
+    def get_public_dsn(self, scheme='https'):
         """
-        Returns a public DSN which is consumable by raven-js
+        Returns a public DSN which is consumable by raven-js.
 
-        >>> # Return scheme-less DSN
         >>> print client.get_public_dsn()
-
-        >>> # Specify a scheme to use (http or https)
-        >>> print client.get_public_dsn('https')
         """
         if not self.is_enabled():
             return
-        url = self.remote.get_public_dsn()
-        if not scheme:
-            return url
-        return '%s:%s' % (scheme, url)
+        return '%s:%s' % (scheme, self.remote.get_public_dsn())
 
     def _get_exception_key(self, exc_info):
         # On certain celery versions the tb_frame attribute might

--- a/raven/contrib/django/templatetags/raven.py
+++ b/raven/contrib/django/templatetags/raven.py
@@ -14,6 +14,6 @@ register = template.Library()
 
 
 @register.simple_tag
-def sentry_public_dsn(scheme=None):
+def sentry_public_dsn(scheme='https'):
     from raven.contrib.django.models import client
     return client.get_public_dsn(scheme) or ''

--- a/tests/base/tests.py
+++ b/tests/base/tests.py
@@ -250,9 +250,9 @@ class ClientTest(TestCase):
         self.assertEquals(data, self.client.decode(encoded))
 
     def test_get_public_dsn(self):
-        client = Client('http://public:secret@example.com/1')
+        client = Client('https://public:secret@example.com/1')
         public_dsn = client.get_public_dsn()
-        self.assertEquals(public_dsn, '//public@example.com/1')
+        self.assertEquals(public_dsn, 'https://public@example.com/1')
 
     def test_explicit_message_on_message_event(self):
         self.client.captureMessage(message='test', data={

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -561,12 +561,7 @@ class DjangoTemplateTagTest(TestCase):
     @mock.patch('raven.contrib.django.DjangoClient.get_public_dsn')
     def test_sentry_public_dsn_no_args(self, get_public_dsn):
         sentry_public_dsn()
-        get_public_dsn.assert_called_once_with(None)
-
-    @mock.patch('raven.contrib.django.DjangoClient.get_public_dsn')
-    def test_sentry_public_dsn_with_https(self, get_public_dsn):
-        sentry_public_dsn('https')
-        get_public_dsn.assert_called_once_with('https')
+        get_public_dsn.assert_called_once()
 
 
 class DjangoLoggingTest(TestCase):


### PR DESCRIPTION
The API enforces https, the DSN returned should match.

The issue with proto-relative is that it creates CORS errors.

On http, the call results in:

> 307 Internal Redirect
> Location:https://app.getsentry.com/api/....

and the console errors:

> XMLHttpRequest cannot load .... Origin 'null' is therefore not allowed access.

The event is is still successfully logged.

The error is, at best, annoying. At worst, if you're a dope like me (stumped by some IE bug) you let the error become a red herring and blame raven-js for your woes.

The `scheme` argument can not be purged without breaking backward compatibility. Folks already using:

```
{% sentry_public_dsn 'https' %}
```

will see no change. Those using:

```
{% sentry_public_dsn %}
```

Will no longer get a console error.
