### PR TITLE
Fixed Django 2.0 compatibility.

### DIFF
--- a/tests/contrib/django/test_resolver.py
+++ b/tests/contrib/django/test_resolver.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import django
+
 try:
     from django.conf.urls import url, include
 except ImportError:
@@ -8,9 +10,14 @@ except ImportError:
 
 from raven.contrib.django.resolver import RouteResolver
 
-included_url_conf = (
-    url(r'^foo/bar/(?P<param>[\w]+)', lambda x: ''),
-), '', ''
+if django.VERSION < (1, 9):
+    included_url_conf = (
+        url(r'^foo/bar/(?P<param>[\w]+)', lambda x: ''),
+    ), '', ''
+else:
+    included_url_conf = ((
+        url(r'^foo/bar/(?P<param>[\w]+)', lambda x: ''),
+    ), '')
 
 example_url_conf = (
     url(r'^api/(?P<project_id>[\w_-]+)/store/$', lambda x: ''),

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -13,7 +13,6 @@ import sys
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import SuspiciousOperation
-from django.core.urlresolvers import reverse
 from django.core.signals import got_request_exception
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import QueryDict
@@ -22,6 +21,12 @@ from django.test import TestCase
 from django.test.client import Client as DjangoTestClient, ClientHandler as DjangoTestClientHandler
 from django.utils.translation import gettext_lazy
 from exam import fixture
+
+try:
+    from django.urls import reverse
+except ImportError:
+    # For Django version less than 1.10.
+    from django.core.urlresolvers import reverse
 
 from raven.base import Client
 from raven.utils.compat import StringIO, iteritems, PY2, string_types, text_type


### PR DESCRIPTION
Fixed Django 2.0 compatibility due to:
- `django.conf.urls.include` parameters change (see Django documentation [1.8](https://docs.djangoproject.com/en/1.8/ref/urls/#include), [2.0](https://docs.djangoproject.com/en/dev/ref/urls/#include)),
- `django.core.urlresolvers` move to `django.urls` (see Django 1.10 [release notes](https://docs.djangoproject.com/en/1.11/releases/1.10/#id3)).