### PR TITLE
Fire signal after setup_logging is called for Flask usage

### DIFF
--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -17,6 +17,7 @@ else:
 
 import logging
 
+import blinker
 from flask import request, current_app, g
 from flask.signals import got_request_exception, request_finished
 from werkzeug.exceptions import ClientDisconnected
@@ -29,7 +30,10 @@ from raven.utils.compat import urlparse
 from raven.utils.encoding import to_unicode
 from raven.utils.wsgi import get_headers, get_environ
 from raven.utils.conf import convert_options
-from raven.utils.signals import logging_configured
+
+
+raven_signals = blinker.Namespace()
+logging_configured = raven_signals.signal('logging_configured')
 
 
 def make_client(client_cls, app, dsn=None):

--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -29,6 +29,7 @@ from raven.utils.compat import urlparse
 from raven.utils.encoding import to_unicode
 from raven.utils.wsgi import get_headers, get_environ
 from raven.utils.conf import convert_options
+from raven.utils.signals import logging_configured
 
 
 def make_client(client_cls, app, dsn=None):
@@ -270,7 +271,11 @@ class Sentry(object):
             if self.logging_exclusions is not None:
                 kwargs['exclude'] = self.logging_exclusions
 
-            setup_logging(SentryHandler(self.client, level=self.level), **kwargs)
+            handler = SentryHandler(self.client, level=self.level)
+            setup_logging(handler, **kwargs)
+
+            logging_configured.send(
+                self, sentry_handler=SentryHandler, **kwargs)
 
         if self.wrap_wsgi:
             app.wsgi_app = SentryMiddleware(app.wsgi_app, self.client)

--- a/raven/utils/signals.py
+++ b/raven/utils/signals.py
@@ -1,7 +1,0 @@
-from __future__ import absolute_import
-import blinker
-
-
-raven_signals = blinker.Namespace()
-
-logging_configured = raven_signals.signal('logging_configured')

--- a/raven/utils/signals.py
+++ b/raven/utils/signals.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+import blinker
+
+
+raven_signals = blinker.Namespace()
+
+logging_configured = raven_signals.signal('logging_configured')

--- a/tests/contrib/flask/tests.py
+++ b/tests/contrib/flask/tests.py
@@ -5,9 +5,8 @@ from flask import Flask, current_app, g
 from flask.ext.login import LoginManager, AnonymousUserMixin, login_user
 from mock import patch, Mock
 
-from raven.contrib.flask import Sentry
+from raven.contrib.flask import Sentry, logging_configured
 from raven.handlers.logging import SentryHandler
-from raven.utils.signals import logging_configured
 from raven.utils.testutils import InMemoryClient, TestCase
 
 


### PR DESCRIPTION
Fire a blinker signal after `setup_logging` is called. 

Replaces #992 

cc @dcramer 