### PR TITLE
Fixed Django 2.0 tests due to MIDDLEWARE_CLASSES remove and error views behavior change.

### DIFF
--- a/tests/contrib/django/urls.py
+++ b/tests/contrib/django/urls.py
@@ -12,11 +12,11 @@ from django.http import HttpResponse
 from tests.contrib.django import views
 
 
-def handler404(request):
+def handler404(request, exception=None):
     return HttpResponse('', status=404)
 
 
-def handler500(request):
+def handler500(request, exception=None):
     if getattr(settings, 'BREAK_THAT_500', False):
         raise ValueError('handler500')
     return HttpResponse('', status=500)


### PR DESCRIPTION
Fixed Django 2.0 tests due to `MIDDLEWARE_CLASSES` remove (see [release notes](https://docs.djangoproject.com/en/dev/releases/1.10/#new-style-middleware)) and error views behavior change (see https://github.com/django/django/commit/3cee9edd1b3e1a11ecdfeecef6f2247c10c859fb).
- `DjangoClientTest.test_404_middleware`,
- `DjangoClientTest.test_404_middleware_when_disabled`,
- `DjangoClientTest.test_request_middleware_exception`,
- `DjangoClientTest.test_response_error_id_middleware`,
- `DjangoClientTest.test_view_middleware_exception`,
- `DjangoClientTest.test_response_middlware_exception`,
- `DjangoClientTest.test_user_info`.