### PR TITLE
Fix initialize import for Django < 1.7

### DIFF
--- a/raven/contrib/django/__init__.py
+++ b/raven/contrib/django/__init__.py
@@ -7,13 +7,6 @@ raven.contrib.django
 """
 from __future__ import absolute_import
 
-import django
-
 default_app_config = 'raven.contrib.django.apps.RavenConfig'
 
 from .client import DjangoClient  # NOQA
-
-# Django 1.8 uses ``raven.contrib.apps.RavenConfig``
-if django.VERSION < (1, 7, 0):
-    from .models import initialize
-    initialize()

--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -15,6 +15,7 @@ import logging
 import sys
 import warnings
 
+import django
 from django.conf import settings
 from django.core.signals import got_request_exception, request_started
 from threading import Lock
@@ -261,3 +262,7 @@ def initialize():
             get_client()  # NOQA
         except Exception:
             _initialized = False
+
+# Django 1.8 uses ``raven.contrib.apps.RavenConfig``
+if django.VERSION < (1, 7, 0):
+    initialize()


### PR DESCRIPTION
This is a Django < 1.7 only issue (tested on 1.5 and 1.6).

#1033 stopped exceptions for #1013,  however `register_serializers()` in https://github.com/getsentry/raven-python/blob/0b4609aa4e6a4a749dc4bd7c019c76d80a5db899/raven/contrib/django/models.py#L262 caused an exception which didn't get shown - leaving raven unconfigured.

This patch delays the initialisation of raven until models.py is loaded for older versions of Django. This is slightly earlier than the app ready which Django 1.7 app loading has, however it's a bit better than whenever `__init__.py` in `raven.contrib.django` gets hit - which seems too early.