### PR TITLE
breadcrumbs: Check logging._srcfile in _patch_logger

### DIFF
--- a/raven/breadcrumbs.py
+++ b/raven/breadcrumbs.py
@@ -200,6 +200,13 @@ def _wrap_logging_method(meth, level=None):
 
 
 def _patch_logger():
+    if logging._srcfile is None:
+        logger.warning(
+            'Frame introspection not available. '
+            'Cannot instrument logging for breadcrumbs.'
+        )
+        return
+
     cls = logging.Logger
 
     methods = {


### PR DESCRIPTION
The _srcfile attribute of the logging module may be None if the
interpreter doesn't support frame introspection (see comment in
logging/__init__.py and #1051).
