### PR TITLE
Extend stack to exc_info

### DIFF
--- a/raven/events.py
+++ b/raven/events.py
@@ -109,12 +109,36 @@ class Exception(BaseEvent):
             'stacktrace': stack_info,
         }
 
+    @staticmethod
+    def full_stacktrace(t, v, tb):
+        class FauxTb(object):
+            def __init__(self, tb_frame, tb_lineno, tb_next):
+                self.tb_frame = tb_frame
+                self.tb_lineno = tb_lineno
+                self.tb_next = tb_next
+
+        def extend_tb(tb):
+            f = tb.tb_frame
+            lst = []
+            while f is not None:
+                lst.append((f, f.f_lineno))
+                f = f.f_back
+            head = tb
+            for tb_frame, tb_lineno in lst[1:]:
+                head = FauxTb(tb_frame, tb_lineno, head)
+            return head
+
+        full_tb = extend_tb(tb)
+        return t, v, full_tb
+
     def capture(self, exc_info=None, **kwargs):
         if not exc_info or exc_info is True:
             exc_info = sys.exc_info()
 
         if not exc_info:
             raise ValueError('No exception found')
+
+        exc_info = self.full_stacktrace(*exc_info)
 
         values = []
         for exc_info in _chained_exceptions(exc_info):


### PR DESCRIPTION
I ran the following code (`scripts/sth.py`) and got reversed Traceback on sentry.

```python
import raven

from config import SENTRY_DSN


def func():
    try:
        raise Exception('Dummy')
    except:
        raven.Client(SENTRY_DSN).captureException(stack=True)
        raise


def func2():
    func()


func2()

```

Raw Exception on sentry:
```
Exception: Dummy
  File "raven/base.py", line 406, in build_msg
    capture_locals=self.capture_locals,
  File "raven/base.py", line 624, in capture
    **kwargs)
  File "raven/base.py", line 799, in captureException
    'raven.events.Exception', exc_info=exc_info, **kwargs)
  File "scripts/sth.py", line 10, in func
    raven.Client(SENTRY_DSN).captureException(stack=True)
  File "scripts/sth.py", line 15, in func2
    func()
  File "scripts/sth.py", line 18, in <module>
    func2()
```

But I was expecting something like:

```
Traceback (most recent call last):
  File "/opt/project/fengmingx/scripts/sth.py", line 18, in <module>
    func2()
  File "/opt/project/fengmingx/scripts/sth.py", line 15, in func2
    func()
  File "/opt/project/fengmingx/scripts/sth.py", line 8, in func
    raise Exception('Dummy')
Exception: Dummy
```

I wonder if raven is designed to print Traceback like this:
- In reversed order
- Including how raven generate the output

Now I am using the hack in [this page](https://stackoverflow.com/questions/13210436/get-full-traceback/13210518) to bypass the problem, and I am wondering if there is a better solution.