### PR TITLE
Fix issue #1064: Resource leak when register_signal=False

### DIFF
--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -285,10 +285,10 @@ class Sentry(object):
             app.wsgi_app = SentryMiddleware(app.wsgi_app, self.client)
 
         app.before_request(self.before_request)
+        request_finished.connect(self.after_request, sender=app)
 
         if self.register_signal:
             got_request_exception.connect(self.handle_exception, sender=app)
-            request_finished.connect(self.after_request, sender=app)
 
         if not hasattr(app, 'extensions'):
             app.extensions = {}


### PR DESCRIPTION
Memory leak fix for issue #1064 

Fix the `raven.contrib.flask.Sentry` client so that the `after_request` handler is called to release all resources in all cases.