### PR TITLE
fix(flask): Add app.logger instrumentation

### DIFF
--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -274,9 +274,11 @@ class Sentry(object):
             kwargs = {}
             if self.logging_exclusions is not None:
                 kwargs['exclude'] = self.logging_exclusions
-
             handler = SentryHandler(self.client, level=self.level)
             setup_logging(handler, **kwargs)
+
+            if app.logger.propagate is False:
+                 app.logger.addHandler(handler)
 
             logging_configured.send(
                 self, sentry_handler=SentryHandler, **kwargs)

--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -278,7 +278,7 @@ class Sentry(object):
             setup_logging(handler, **kwargs)
 
             if app.logger.propagate is False:
-                 app.logger.addHandler(handler)
+                app.logger.addHandler(handler)
 
             logging_configured.send(
                 self, sentry_handler=SentryHandler, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ envlist =
     py27-django-16
     {py27,py35}-flask-{10,11}
     py35-flask-12
+    py35-flask-dev
     py27-celery-{3,4}
 
 
@@ -37,6 +38,8 @@ deps =
     flask-10: Flask>=0.10,<0.11
     flask-11: Flask>=0.11,<0.12
     flask-12: Flask>=0.12,<0.13
+    flask-dev: git+https://github.com/pallets/flask.git#egg=flask
+    flask-dev: flask-login
     celery-3: Celery>=3.1,<3.2
     celery-4: Celery>=4.0,<4.1
     fix: git+https://github.com/pytest-dev/pytest-django.git#egg=pytest_django


### PR DESCRIPTION
Older versions of flask set app.logger.propagate to False,
and it's reasonable to expect that users except app.logger
to be instrumented if explictly setting logger=True in the
sentry client.

Fixes: PY-RAVEN #1030 app.logger log call messages are not send to
sentry