### PR TITLE
fix(flask): Use request.get_json instead of data

### DIFF
--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -191,7 +191,7 @@ class Sentry(object):
         return request.form
 
     def get_json_data(self, request):
-        return request.data
+        return request.get_json()
 
     def get_http_info_with_retriever(self, request, retriever=None):
         """


### PR DESCRIPTION
request.data returns a string when we are expecting json/dict
as the event data.

PY-RAVEN Fixes #1067