### PR TITLE
Added Django setting to ignore expected Celery errors

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -296,6 +296,12 @@ Additional Settings
             'CELERY_LOGLEVEL': logging.INFO
         }
 
+.. describe:: SENTRY_CELERY_IGNORE_EXPECTED
+
+    If you are also using Celery, then you can ignore expected exceptions by
+    setting this to ``True``. This will cause exception classes in
+    ``Task.throws`` to be ignored.
+
 Caveats
 -------
 

--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -165,7 +165,13 @@ class SentryDjangoHandler(object):
             SentryCeleryHandler, register_logger_signal
         )
 
-        self.celery_handler = SentryCeleryHandler(client).install()
+        ignore_expected = getattr(settings,
+                                  'SENTRY_CELERY_IGNORE_EXPECTED',
+                                  False)
+
+        self.celery_handler = SentryCeleryHandler(client,
+                                                  ignore_expected=ignore_expected)\
+                                                  .install()
 
         # try:
         #     ga = lambda x, d=None: getattr(settings, 'SENTRY_%s' % x, d)


### PR DESCRIPTION
After installing Raven by adding `raven.contrib.django.raven_compat` to `INSTALLED_APPS` in Django, `SentryCeleryHandler` gets set up, but there is no option to ignore expected exceptions for Celery, even though that is something that `SentryCeleryHandler` has an option for.

I have updated this to add that to be configured as a Django setting. The reason is that we were running into an issue where many expected errors were being reported and we couldn't find a way to stop it apart from monkeypatching `SentryDjangoHandler`.