### PR TITLE
Add setting check for instrumenting celery

### DIFF
--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -158,6 +158,7 @@ class SentryDjangoHandler(object):
         else:
             self.has_celery = celery.VERSION >= (2, 5)
 
+        self.instrument_celery = getattr(settings, 'SENTRY_INSTRUMENT_CELERY', True)
         self.celery_handler = None
 
     def install_celery(self):
@@ -181,7 +182,7 @@ class SentryDjangoHandler(object):
         request_started.connect(self.before_request, weak=False)
         got_request_exception.connect(self.exception_handler, weak=False)
 
-        if self.has_celery:
+        if self.has_celery and self.instrument_celery:
             try:
                 self.install_celery()
             except Exception:


### PR DESCRIPTION
Docs still missing, and this is just a provisional quickfix-remediation for issue 1074.
Don't want to put too much effort as how python-raven handles settings in general
is one of the first big refactoring tickets I want to go for.