### PR TITLE
Add `application/octet-stream` to non-cacheable types

### DIFF
--- a/raven/contrib/django/middleware/__init__.py
+++ b/raven/contrib/django/middleware/__init__.py
@@ -121,15 +121,20 @@ SentryLogMiddleware = SentryMiddleware
 
 
 class DjangoRestFrameworkCompatMiddleware(MiddlewareMixin):
+
+    non_cacheable_types = (
+        'application/x-www-form-urlencoded',
+        'multipart/form-data',
+        'application/octet-stream'
+    )
+
     def process_request(self, request):
         """
         Access request.body, otherwise it might not be accessible later
         after request has been read/streamed
         """
         content_type = request.META.get('CONTENT_TYPE', '')
-        if 'application/x-www-form-urlencoded' in content_type:
-            pass
-        elif 'multipart/form-data' in content_type:
-            pass
-        else:
-            request.body  # forces stream to be read into memory
+        for non_cacheable_type in self.non_cacheable_types:
+            if non_cacheable_type in content_type:
+                return
+        request.body  # forces stream to be read into memory


### PR DESCRIPTION
Noticed Django was throwing out the following for raw file uploads over the `DATA_UPLOAD_MAX_MEMORY_SIZE`:
```
...
[ERROR] django.security.RequestDataTooBig: Request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.
...
```

Seems to be caused by the questionable `DjangoRestFrameworkCompatMiddleware` poking at `request.body`. This causes Django to evaluate the data size too early and see the file body as part of the rest of the data payload, when `DATA_UPLOAD_MAX_MEMORY_SIZE` should discount file payloads.

Refactored slightly and added `application/octet-stream` as another type that shouldn't be cached.