### PR TITLE
SQS Transport Capability

### DIFF
--- a/raven/transport/sqs.py
+++ b/raven/transport/sqs.py
@@ -1,0 +1,62 @@
+"""
+raven.transport.sqs
+~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+
+:author: Mike Grima <mikegrima>
+"""
+from __future__ import absolute_import
+import base64
+import json
+
+import boto3
+
+from raven.utils.compat import string_types
+from raven.conf import defaults
+from raven.transport.base import Transport
+
+
+class SQSTransport(Transport):
+    scheme = ['sqs+https', 'sqs+http']
+
+    def __init__(self, sqs_region, sqs_account, sqs_name,
+                 timeout=defaults.TIMEOUT, verify_ssl=True,
+                 ca_certs=defaults.CA_BUNDLE):
+        # Stuff the docs require:
+        if isinstance(timeout, string_types):
+            timeout = int(timeout)
+        if isinstance(verify_ssl, string_types):
+            verify_ssl = bool(int(verify_ssl))
+
+        self.timeout = timeout
+        self.verify_ssl = verify_ssl
+        self.ca_certs = ca_certs
+        #####################
+
+        # Stuff SQS requires:
+        self.sqs_name = sqs_name
+        self.sqs_account = sqs_account
+        self.sqs_client = boto3.client("sqs", region_name=sqs_region)
+        self.queue_url = None
+
+    def send(self, url, data, headers):
+        """
+        Sends a request to an SQS queue -- to be later popped off
+        later for submission into Sentry.
+
+        Note: This will simply raise any Boto ClientErrors that are encountered.
+        """
+        if not self.queue_url:
+            self.queue_url = self.sqs_client.get_queue_url(QueueName=self.sqs_name,
+                                                           QueueOwnerAWSAccountId=self.sqs_account)["QueueUrl"]
+
+        payload = {
+            "url": url,
+            "headers": headers,
+            "data": base64.b64encode(data).decode("utf-8")
+        }
+
+        self.sqs_client.send_message(QueueUrl=self.queue_url,
+                                     MessageBody=json.dumps(payload))

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ tests_require = [
     'webtest',
     'anyjson',
     'ZConfig',
+    'moto'
 ] + (
     flask_requires + flask_tests_requires +
     unittest2_requires + webpy_tests_requires
@@ -118,6 +119,7 @@ setup(
         'flask': flask_requires,
         'tests': tests_require,
         ':python_version<"3.2"': ['contextlib2'],
+        'aws': ['boto3'],
     },
     license='BSD',
     tests_require=tests_require,

--- a/tests/transport/sqs/tests.py
+++ b/tests/transport/sqs/tests.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+raven.tests.transport.sqs.tests
+~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+
+:author: Mike Grima <mikegrima>
+"""
+from __future__ import absolute_import
+import boto3
+
+from raven.transport.sqs import SQSTransport
+from raven.utils.testutils import TestCase
+from raven.base import Client
+
+# Simplify comparing dicts with primitive values:
+from raven.utils import json
+import zlib
+
+from moto import mock_sqs
+
+import base64
+
+
+class SQSTest(TestCase):
+    def test_sqs_transport(self):
+        mock_sqs().start()
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        sqs.create_queue(QueueName="sentry-queue")
+
+        c = Client(dsn="mock://some_username:some_password@localhost:8143/1"
+                       "?sqs_region=us-east-1&sqs_account=123456789012&sqs_name=sentry-queue",
+                   transport=SQSTransport)
+
+        data = dict(a=42, b=55, c=list(range(50)))
+        expected_message = zlib.decompress(c.encode(data))
+
+        c.send(**data)
+
+        transport = c._transport_cache["mock://some_username:some_password@localhost:8143/1"
+                                       "?sqs_region=us-east-1&sqs_account=123456789012"
+                                       "&sqs_name=sentry-queue"].get_transport()
+
+        self.assertEqual(transport.sqs_account, "123456789012")
+        self.assertEqual(transport.sqs_name, "sentry-queue")
+        self.assertTrue(type(transport.sqs_client).__name__, type(sqs).__name__)
+        self.assertEquals(transport.queue_url, "https://queue.amazonaws.com/123456789012/sentry-queue")
+
+        # Check SQS for the message that was sent over:
+        messages = sqs.receive_message(QueueUrl=transport.queue_url)["Messages"]
+        self.assertEqual(len(messages), 1)
+
+        body = json.loads(messages[0]["Body"])
+
+        self.assertEqual(body["url"], "mock://localhost:8143/api/1/store/")
+        self.assertTrue("sentry_secret=some_password" in body["headers"]["X-Sentry-Auth"])
+
+        decoded_data = base64.b64decode(body["data"])
+
+        self.assertEqual(
+            json.dumps(json.loads(expected_message.decode('utf-8')), sort_keys=True),
+            json.dumps(c.decode(decoded_data), sort_keys=True)
+        )
+
+        mock_sqs().stop()


### PR DESCRIPTION
Hello:

This PR adds a `SQSTransport` class to the Transports.

**What does this do?**
Instead of forwarding messages directly to Sentry, it forwards them over to an SQS queue. Then, an SQS poller pops off the messages before sending them onto Sentry.

I just created some simple code on GitHub here that does this: https://github.com/Netflix-Skunkworks/raven-sqs-proxy

**Why is this useful?**
The primary use case of this is with AWS Lambda functions. For lambda functions to write to an AWS Sentry instance, it would need to reside within a VPC. Running lambdas inside of a VPC requires that the lambda be assigned an ENI.

There are many use-cases where running a lambda within a VPC is not feasible, such as:
1. An AWS account doesn't have a useful VPC (special purpose accounts)
1. An AWS account doesn't have a VPC that is peered to a VPC where Sentry is running
1. Cross-region use cases where Sentry lives in an internal VPC without external connectivity
1. **ENI Exhaustion Concerns**: It is possible to exhaust the ENIs within a VPC if you have many, many lambdas running. This can break new deployments within a VPC.

For any of the above use cases, SQS alleviates the drawbacks. In this case, the lambda is still able to take advantage of Sentry by posting to an SQS queue. A VPC ENI need not be required. Security to the SQS queue is handled via IAM Roles.

**Potential Concern**
This PR simply passes the headers with the DSN credentials onto SQS. If this is a concern, I can add a KMS option to encrypt credentials before passing onto SQS.

Please let me know if there are additional changes that can be made or if you have any questions about my approach.

Thank You