### PR TITLE
doco for user context and tags for logging integrations

### DIFF
--- a/docs/integrations/logging.rst
+++ b/docs/integrations/logging.rst
@@ -117,6 +117,13 @@ capturing for all messages::
 
     logger.error('There was an error, with a stacktrace!')
 
+Passing tags and user context is also available through extra::
+
+    logger.error('There was an error, with user context and tags'), extra={
+        'user': {'email': 'test@test.com},
+        'tags': {'database': '1.0'},
+    })
+
 You may also pass additional information to be stored as meta information with
 the event. As long as the key name is not reserved and not private (_foo) it
 will be displayed on the Sentry dashboard. To do this, pass it as ``data``


### PR DESCRIPTION
Thought I'd help out and add the tags and user context syntax to the logging integrations docs