### PR TITLE
Support partial exc_info using logger

### DIFF
--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -160,7 +160,7 @@ class SentryHandler(logging.Handler, object):
 
         # If there's no exception being processed, exc_info may be a 3-tuple of None
         # http://docs.python.org/library/sys.html#sys.exc_info
-        if record.exc_info and all(record.exc_info):
+        if record.exc_info and not all(x is None for x in record.exc_info):
             # capture the standard message first so that we ensure
             # the event is recorded as an exception, in addition to having our
             # message interface attached

--- a/tests/handlers/logging/tests.py
+++ b/tests/handlers/logging/tests.py
@@ -142,6 +142,31 @@ class LoggingIntegrationTest(TestCase):
         self.assertEqual(msg['message'], 'This is a test info with an exception')
         self.assertEqual(msg['params'], ())
 
+    def test_logger_partial_exc_info(self):
+        try:
+            raise ValueError('This is a test ValueError')
+        except ValueError:
+            exc_info = sys.exc_info()
+            exc_info = (exc_info[0], exc_info[1], None)
+            record = self.make_record('This is a test info with an exception', exc_info=exc_info)
+        else:
+            self.fail('Should have raised an exception')
+
+        self.handler.emit(record)
+
+        self.assertEqual(len(self.client.events), 1)
+        event = self.client.events.pop(0)
+
+        self.assertEqual(event['message'], 'This is a test info with an exception')
+        assert 'exception' in event
+        exc = event['exception']['values'][-1]
+        self.assertEqual(exc['type'], 'ValueError')
+        self.assertEqual(exc['value'], 'This is a test ValueError')
+        self.assertTrue('sentry.interfaces.Message' in event)
+        msg = event['sentry.interfaces.Message']
+        self.assertEqual(msg['message'], 'This is a test info with an exception')
+        self.assertEqual(msg['params'], ())
+
     def test_message_params(self):
         record = self.make_record('This is a test of %s', args=('args',))
         self.handler.emit(record)


### PR DESCRIPTION
In our application we were logging exceptions that have been captured and saved. To enter these we use the tri-tuple exc_info format. The framework we use that captures these exceptions (graphql-core) provides us with the exception information missing the stack. Sentry would log something but totally skip the exception information.

This change checks if all the exc_info is (None, None, None) or tries to parse the partial exc_info, still providing the exception class and message in the Sentry event