### PR TITLE
Remove test dependency on pytest-assume

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ tests_require = [
     'pytest-xdist==1.18.2',
     'pytest-pythonpath==0.7.1',
     'pytest-sugar==0.8',
-    'pytest-assume',
     'pytest-cov',
     'pytest-flake8==0.9',
     'requests',


### PR DESCRIPTION
This was added in #1056 by @ashwoods. Unless I am mistaken, this module is not used
by raven tests and do not modify its behavior either.