### PR TITLE
Work around a crash in Django 2.0 URLResolver handling

### DIFF
--- a/raven/contrib/django/resolver.py
+++ b/raven/contrib/django/resolver.py
@@ -50,6 +50,10 @@ class RouteResolver(object):
         return result
 
     def _resolve(self, resolver, path, parents=None):
+        if not hasattr(resolver, "regex"):
+            # Happens in Django 2.0. TODO #1127.
+            return
+
         match = resolver.regex.search(path)
         if not match:
             return


### PR DESCRIPTION
This is a workaround for #1127... it doesn't fix it, but at least it prevents Raven from crashing, and should fall back on behaviour of the URL resolution being ignored.

Django 2.0 has made fairly extensive changes to URL resolution and I don't fully understand how this handling works in Raven so I don't know if I can actually fix it the right way.