### PR TITLE
Add support for asyncio compatible transport.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,10 @@ jobs:
       python: 3.6
       env: TOXENV=py36-lambda
 
+    - stage: contrib
+      python: 3.6
+      env: TOXENV=py36-aiohttp
+
     - stage: deploy
       script: ./setup.py sdist --formats=gztar bdist_wheel
       if: branch = master

--- a/docs/transports.rst
+++ b/docs/transports.rst
@@ -122,3 +122,15 @@ Should only be used within a Twisted event loop.
     from raven.transport.twisted import TwistedHTTPTransport
 
     Client('...', transport=TwistedHTTPTransport)
+
+Aiohttp
+-------
+
+Should only be used within an asyncio event loop.
+
+.. code-block:: python
+
+   from raven.contrib.aiohttp.client import AIOHTTPClient
+   from raven.transport.aiohttp import AIOHTTPHTTPTransport
+
+   AIOHTTPClient('...', transport=AIOHTTPHTTPTransport)

--- a/raven/contrib/aiohttp/client.py
+++ b/raven/contrib/aiohttp/client.py
@@ -1,0 +1,38 @@
+import asyncio
+from functools import partial
+
+from raven.base import Client
+
+
+def task_callback(client, failed_send, future):
+    try:
+        future.result()
+    except Exception as e:
+        if client.raise_send_errors:
+            raise e
+        failed_send(e)
+    else:
+        client._successful_send()
+
+
+class AIOHTTPClient(Client):
+    def send_remote(self, url, data, headers=None):
+        # If the client is configured to raise errors on sending,
+        # the implication is that the backoff and retry strategies
+        # will be handled by the calling application
+        if headers is None:
+            headers = {}
+
+        if not self.raise_send_errors and not self.state.should_try():
+            data = self.decode(data)
+            self._log_failed_submission(data)
+            return
+
+        self.logger.debug('Sending message of length %d to %s', len(data), url)
+
+        def failed_send(e):
+            self._failed_send(e, url, self.decode(data))
+
+        transport = self.remote.get_transport()
+        task = asyncio.ensure_future(transport.send(url, data, headers))
+        task.add_done_callback(partial(task_callback, self, failed_send))

--- a/raven/transport/aiohttp.py
+++ b/raven/transport/aiohttp.py
@@ -1,0 +1,61 @@
+"""
+raven.transport.aiohttp
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+import asyncio
+
+from raven.exceptions import APIError, RateLimited
+from raven.transport.http import HTTPTransport
+
+try:
+    import aiohttp
+    from aiohttp import ClientError
+    has_aiohttp = True
+except ImportError:
+    has_aiohttp = False
+
+
+class AIOHTTPHTTPTransport(HTTPTransport):
+
+    scheme = ['aiohttp+http', 'aiohttp+https']
+
+    def __init__(self, *args, **kwargs):
+        if not has_aiohttp:
+            raise ImportError('AIOHTTPHTTPTransport requires aiohttp.')
+        loop = asyncio.get_event_loop()
+        self.client = aiohttp.ClientSession(loop=loop)
+        super().__init__(*args, **kwargs)
+
+    async def send(self, url, data, headers):
+        try:
+            with aiohttp.Timeout(self.timeout):
+                async with self.client.post(
+                        url, data=data, headers=headers) as response:
+                    try:
+                        response.raise_for_status()
+                    except ClientError as e:
+                        msg = response.headers.get('x-sentry-error')
+                        if response.status == 429:
+                            try:
+                                retry_after = int(response.headers.get('retry-after'))
+                            except (ValueError, TypeError):
+                                retry_after = 0
+                            raise RateLimited(msg, retry_after)
+                        raise APIError(msg, response.status) from e
+                    else:
+                        return response
+        except asyncio.TimeoutError as e:
+            message = ("Connection to Sentry server timed out "
+                       "(url: %s, timeout: %d seconds)" % (url, self.timeout))
+            raise APIError(message, 504) from e
+
+    @staticmethod
+    def handler(success, error, future):
+        try:
+            future.result()
+            success()
+        except Exception as e:
+            error(e)

--- a/raven/transport/registry.py
+++ b/raven/transport/registry.py
@@ -8,6 +8,7 @@ raven.transport.registry
 from __future__ import absolute_import
 
 # TODO(dcramer): we really should need to import all of these by default
+from .aiohttp import AIOHTTPHTTPTransport
 from raven.transport.eventlet import EventletHTTPTransport
 from raven.transport.exceptions import DuplicateScheme
 from raven.transport.http import HTTPTransport
@@ -72,4 +73,5 @@ default_transports = [
     ThreadedRequestsHTTPTransport,
     TornadoHTTPTransport,
     EventletHTTPTransport,
+    AIOHTTPHTTPTransport,
 ]

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,18 @@ webpy_tests_requires = [
     'web.py',
 ]
 
+asyncio_tests_requires = [
+    'pytest-asyncio',
+]
+
 # If it's python3, remove unittest2 & web.py
 if sys.version_info[0] == 3:
     unittest2_requires = []
     webpy_tests_requires = []
+    webpy_tests_requires = []
+# asycnio support is only compatible with python3.6+
+if sys.version_info < (3, 6):
+    asyncio_tests_requires = []
 
 tests_require = [
     'bottle',
@@ -81,7 +89,8 @@ tests_require = [
     'ZConfig',
 ] + (
     flask_requires + flask_tests_requires +
-    unittest2_requires + webpy_tests_requires
+    unittest2_requires + webpy_tests_requires +
+    asyncio_tests_requires
 )
 
 
@@ -117,6 +126,7 @@ setup(
         'flask': flask_requires,
         'tests': tests_require,
         ':python_version<"3.2"': ['contextlib2'],
+        'aiohttp': ['aiohttp'],
     },
     license='BSD',
     tests_require=tests_require,

--- a/tests/contrib/aiohttp/test_client.py
+++ b/tests/contrib/aiohttp/test_client.py
@@ -1,0 +1,38 @@
+import asyncio
+
+import pytest
+
+from raven.contrib.aiohttp.client import AIOHTTPClient
+
+
+@pytest.fixture
+def mock_transport(request):
+
+    class MockTransport:
+        def __init__(self, *args, **kwargs):
+            self.called = False
+
+        async def send(self, url, data, headers):
+            self.called = True
+            if 'with_error' in request.keywords:
+                raise ValueError
+
+    return MockTransport
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('with_error', [False, True], ids=['without_error', 'with_error'])
+async def test_aiohttp_client(mock_transport, mocker, with_error):
+    dsn = 'htttps://user:pass@host:1234/1'
+    client = AIOHTTPClient(dsn=dsn,
+                           transport=mock_transport)
+    success = mocker.spy(client, '_successful_send')
+    failure = mocker.spy(client, '_log_failed_submission')
+    client.captureMessage('test')
+
+    await asyncio.sleep(.1)
+    assert client.remote.get_transport().called
+    if with_error:
+        failure.assert_called()
+    else:
+        success.assert_called()

--- a/tests/transport/aiohttp/tests.py
+++ b/tests/transport/aiohttp/tests.py
@@ -1,0 +1,106 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import aiohttp.web
+from aiohttp.client import _RequestContextManager
+from aiohttp.client_reqrep import ClientResponse
+import pytest
+from yarl import URL
+
+from raven.contrib.aiohttp.client import AIOHTTPClient
+import raven.transport.aiohttp
+from raven.transport.aiohttp import AIOHTTPHTTPTransport
+
+
+class PosterMock(MagicMock):
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class TimeoutPosterMock(PosterMock):
+    async def __aenter__(self):
+        await asyncio.sleep(1.1)
+        return self
+
+
+class AsyncMockContextManager(_RequestContextManager):
+
+    async def __aexit__(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture
+def mock_client_post(mocker, request):
+    if 'with_timeout' in request.keywords:
+        mock = TimeoutPosterMock()
+    else:
+        mock = PosterMock()
+
+    return mocker.patch.object(
+        raven.transport.aiohttp.aiohttp.ClientSession, 'post', mock)
+
+
+@pytest.fixture
+def mock_client_post_error(mocker):
+
+    mock = PosterMock(side_effect=aiohttp.ClientError())
+    return mocker.patch.object(
+        raven.transport.aiohttp.aiohttp.ClientSession, 'post', mock)
+
+
+@pytest.fixture
+def mock_client_post_throttled(mocker):
+    throttled_response = ClientResponse(
+        'get', URL('htttps://host:1234/api/1/store/'))
+    throttled_response.status = 429
+    throttled_response.headers = {'retry-after': 1}
+
+    async def coro(resp):
+        return resp
+
+    mock = mocker.Mock(
+        return_value=AsyncMockContextManager(coro(throttled_response)))
+    return mocker.patch.object(
+        raven.transport.aiohttp.aiohttp.ClientSession, 'post', mock)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('with_timeout', [True, False],
+                         ids=['with_timeout', 'without_timeout'])
+async def test_aiohttp_http_transport(mock_client_post, with_timeout, caplog):
+    dsn = 'htttps://user:pass@host:1234/1?timeout={:d}'.format(with_timeout)
+    client = AIOHTTPClient(
+        dsn=dsn, transport=AIOHTTPHTTPTransport,
+    )
+    client.captureMessage(message='test')
+    await asyncio.sleep(int(with_timeout) + .1)
+    if with_timeout:
+        assert 'Connection to Sentry server timed out' in caplog.text()
+    assert mock_client_post.call_args_list[0][0][0] == 'htttps://host:1234/api/1/store/'
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_http_transport_with_error(mock_client_post_error, caplog):
+    dsn = 'htttps://user:pass@host:1234/1'
+    client = AIOHTTPClient(
+        dsn=dsn, transport=AIOHTTPHTTPTransport,
+    )
+    client.captureMessage(message='test')
+    await asyncio.sleep(.1)
+    assert mock_client_post_error.call_args_list[0][0][0] == 'htttps://host:1234/api/1/store/'
+    assert 'Sentry responded with an error' in caplog.text()
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_http_transport_throttled(mock_client_post_throttled, caplog):
+    dsn = 'htttps://user:pass@host:1234/1'
+    client = AIOHTTPClient(
+        dsn=dsn, transport=AIOHTTPHTTPTransport,
+    )
+    client.captureMessage(message='test')
+    await asyncio.sleep(.1)
+    assert mock_client_post_throttled.call_count == 1
+    assert 'Sentry responded with an API error: RateLimited(None)' in caplog.text()

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ envlist =
     py35-flask-dev
     py27-celery-{3,4}
     py{27,36}-lambda
+    py36-aiohttp
 
 
 [testenv]
@@ -47,6 +48,11 @@ deps =
     celery-3: Celery>=3.1,<3.2
     celery-4: Celery>=4.0,<4.1
     fix: git+https://github.com/pytest-dev/pytest-django.git#egg=pytest_django
+    # remove pytest-capturelog once pytest is upgraded to 3.3.1
+    aiohttp: pytest-capturelog
+    aiohttp: aiohttp
+    aiohttp: pytest-asyncio
+    aiohttp: pytest-mock
 setenv =
     PYTHONDONTWRITEBYTECODE=1
     TESTPATH=tests
@@ -54,6 +60,7 @@ setenv =
     flask: TESTPATH=tests/contrib/flask
     celery: TESTPATH=tests/contrib/test_celery.py
     lambda: TESTPATH=tests/contrib/awslambda
+    aiohttp: TESTPATH=tests/contrib/aiohttp tests/transport/aiohttp
 usedevelop = true
 extras = tests
 


### PR DESCRIPTION
Rely on aiohttp's client to perform the requests.

Note: only python3.6+ is supported as we don't require to pass the loop to
`asyncio.ensure_future`. Only python3.6 handles this correctly by obtaining
the running loop from the context.

https://docs.python.org/3/whatsnew/3.6.html#asyncio