### PR TITLE
folder needs to be created first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ coverage:
 
 setup-git:
 	git config branch.autosetuprebase always
+	mkdir -p .git/hooks
 	cd .git/hooks && ln -sf ../../hooks/* ./
 
 publish:


### PR DESCRIPTION
on clean clone, .git/hooks does not exist so this fails unless directory is created first