### PR TITLE
fix flake8 hook

### DIFF
--- a/hooks/pre-commit.flake8
+++ b/hooks/pre-commit.flake8
@@ -17,13 +17,10 @@ if 'VIRTUAL_ENV' in os.environ:
 
 
 def main():
-    from flake8.main import USER_CONFIG
-    from flake8.engine import get_style_guide
-    from flake8.hooks import run
+    from flake8.main.git import find_modified_files
+    from flake8.api.legacy import get_style_guide
 
-    gitcmd = "git diff-index --cached --name-only HEAD"
-
-    _, files_modified, _ = run(gitcmd)
+    files_modified = find_modified_files(False)
 
     try:
         text_type = unicode
@@ -37,7 +34,7 @@ def main():
         lambda x: x.endswith('.py') and os.path.exists(x),
         files_modified)
 
-    flake8_style = get_style_guide(parse_argv=True, config_file=USER_CONFIG)
+    flake8_style = get_style_guide(parse_argv=True)
     report = flake8_style.check_files(files_modified)
 
     return report.total_errors


### PR DESCRIPTION
pre-commit hook (installed with `make setup-git`) seems to be using flake8 2.x api while setup.py requires 3.5.0 - not sure what to do with USER_CONFIG, so left it out.