### PR TITLE
Fix skipping sanitizer for bytes data in filter_http

### DIFF
--- a/raven/processors.py
+++ b/raven/processors.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 
 import re
 
-from raven.utils.compat import string_types, text_type
+from raven.utils.compat import string_types, text_type, PY3
 from raven.utils import varmap
 
 
@@ -109,6 +109,10 @@ class SanitizeKeysProcessor(Processor):
         for n in ('data', 'cookies', 'headers', 'env', 'query_string'):
             if n not in data:
                 continue
+
+            # data could be provided as bytes
+            if PY3 and isinstance(data[n], bytes):
+                data[n] = data[n].decode('utf-8', 'replace')
 
             if isinstance(data[n], string_types) and '=' in data[n]:
                 # at this point we've assumed it's a standard HTTP query

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -209,7 +209,7 @@ class DjangoClientTest(TestCase):
                 content_type='application/json')
         assert len(self.raven.events) == 1
         event = self.raven.events.pop(0)
-        assert event['request']['data'] == b'{"a":"b"}'
+        assert event['request']['data'] == '{"a":"b"}'
 
     def test_capture_event_with_request_middleware(self):
         path = reverse('sentry-trigger-event')

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -357,6 +357,12 @@ class SanitizePasswordsProcessorTest(TestCase):
         result = proc.sanitize('__repr__: жили-были', '42')
         self.assertEquals(result, '42')
 
+    def test_sanitize_bytes(self):
+        proc = SanitizePasswordsProcessor(Mock())
+        data = {'data': b'password=1234'}
+        result = proc.filter_http(data)
+        self.assertIn(data['data'], 'password=%s' % proc.MASK)
+
 
 class RemovePostDataProcessorTest(TestCase):
     def test_does_remove_data(self):


### PR DESCRIPTION
Hi!

This is attempt to solve #1080 

`isinstance(..., bytes)` already used in other places.

Thanks!