### PR TITLE
update celery context

### DIFF
--- a/raven/contrib/celery/__init__.py
+++ b/raven/contrib/celery/__init__.py
@@ -99,6 +99,9 @@ class SentryCeleryHandler(object):
             for i, arg in enumerate(args):
                 if arg in self.context_args:
                     tags.update({arg, kw['args'][i]})
+            for k, v in kw['kwargs'].iteritems():
+                if k in self.context_args:
+                    tags.update({k, v})
             context = {'tags': tags}
             self.client.context.merge(context)
         self.client.transaction.push(task.name)


### PR DESCRIPTION
The current implementation of the celery client prevents the ability to pass context on a per process basis.  We have found that being able to tag and filter based on the arguments or key word arguments is immensely helpful in tracking down where failures are in the system.