### PR TITLE
Logging of Remote Host on Python 2

### DIFF
--- a/raven/conf/remote.py
+++ b/raven/conf/remote.py
@@ -57,6 +57,9 @@ class RemoteConfig(object):
     def __unicode__(self):
         return text_type(self.base_url)
 
+    def __str__(self):
+        return text_type(self.base_url)
+
     def is_active(self):
         return all([self.base_url, self.project, self.public_key, self.secret_key])
 


### PR DESCRIPTION
On Python 2.7 (App Engine) the current codes results in a rather unhelpful `Configuring Raven for host: <raven.conf.remote.RemoteConfig object at 0xfa682430>` at startup. It might be better to force Python 2 on base.py at `self.logger.debug("Configuring Raven for host: {0}".format(self.remote))` to evaluate Unicode, but I think at this place it is much more obvious that the code is for Python 2.x sake.