### PR TITLE
Fixing App Engine auto configuration [GH-1192]

### DIFF
--- a/raven/conf/remote.py
+++ b/raven/conf/remote.py
@@ -18,19 +18,26 @@ def discover_default_transport():
     from raven.transport.threaded import ThreadedHTTPTransport
     from raven.transport.http import HTTPTransport
 
+    default_transport = ThreadedHTTPTransport
+
     # Google App Engine
     # https://cloud.google.com/appengine/docs/python/how-requests-are-handled#Python_The_environment
     if 'CURRENT_VERSION_ID' in os.environ and 'INSTANCE_ID' in os.environ:
         logger.info('Detected environment to be Google App Engine. Using synchronous HTTP transport.')
-        return HTTPTransport
+        default_transport = HTTPTransport
 
     # AWS Lambda
     # https://alestic.com/2014/11/aws-lambda-environment/
     if 'LAMBDA_TASK_ROOT' in os.environ:
         logger.info('Detected environment to be AWS Lambda. Using synchronous HTTP transport.')
-        return HTTPTransport
+        default_transport = HTTPTransport
 
-    return ThreadedHTTPTransport
+    if default_transport == HTTPTransport:
+        # make HTTPTransport the default transport for http
+        HTTPTransport.scheme = ['http', 'https', 'sync+http', 'sync+https']
+        ThreadedHTTPTransport.scheme = ['threaded+http', 'threaded+https']
+
+    return default_transport
 
 
 DEFAULT_TRANSPORT = discover_default_transport()


### PR DESCRIPTION
This works around the issue described in #1192. With this patch `Client('https://public_key:secret_key@sentry.io/project_id')` works as expected on Google App Engine and AWS lambda. This archived by monkey patching the  default Transports for `http` and `https`.