### PR TITLE
Mask Complete dictionary instead of just the leaves

### DIFF
--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -44,8 +44,10 @@ def varmap(func, var, context=None, name=None):
         return func(name, '<...>')
     context[objid] = 1
     if isinstance(var, dict):
-        ret = dict((k, varmap(func, v, context, k))
-                   for k, v in iteritems(var))
+        ret = varmap(func, var)
+        if isinstance(ret, dict):
+            ret = dict((k, varmap(func, v, context, k))
+                       for k, v in iteritems(var))
     elif isinstance(var, (list, tuple)):
         ret = [varmap(func, f, context, name) for f in var]
     else:

--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -43,15 +43,13 @@ def varmap(func, var, context=None, name=None):
     if objid in context:
         return func(name, '<...>')
     context[objid] = 1
-    if isinstance(var, dict):
-        ret = varmap(func, var)
-        if isinstance(ret, dict):
-            ret = dict((k, varmap(func, v, context, k))
-                       for k, v in iteritems(var))
-    elif isinstance(var, (list, tuple)):
+    if isinstance(var, (list, tuple)):
         ret = [varmap(func, f, context, name) for f in var]
     else:
         ret = func(name, var)
+        if isinstance(ret, dict):
+            ret = dict((k, varmap(func, v, context, k))
+                       for k, v in iteritems(var))
     del context[objid]
     return ret
 


### PR DESCRIPTION
## What
Allowing the masking of non-leaf nodes if they are present in `sanitize_keys`

## Example
```
sanitize_keys = ['key1', 'key2']
mask = '********'

data_to_mask = {'key1': {'key3': 'val3'}, 'key2': 'val2'}

current_output = {'key1': {'key3': 'val3'}, 'key2': '********'}

new_output = {'key1': '********', 'key2': '********'}
```

## Why
The intent of masking the key is being skipped if the key is not a leaf node.