### PR TITLE
Bump references to 2012-2017 to 2018 in author docstrings.

### DIFF
--- a/raven/__init__.py
+++ b/raven/__init__.py
@@ -2,7 +2,7 @@
 raven
 ~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/base.py
+++ b/raven/base.py
@@ -2,7 +2,7 @@
 raven.base
 ~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/conf/__init__.py
+++ b/raven/conf/__init__.py
@@ -2,7 +2,7 @@
 raven.conf
 ~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/conf/defaults.py
+++ b/raven/conf/defaults.py
@@ -4,7 +4,7 @@ raven.conf.defaults
 
 Represents the default values for all Sentry settings.
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/context.py
+++ b/raven/context.py
@@ -2,7 +2,7 @@
 raven.context
 ~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/__init__.py
+++ b/raven/contrib/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib
 ~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/async.py
+++ b/raven/contrib/async.py
@@ -2,7 +2,7 @@
 raven.contrib.async
 ~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/awslambda/__init__.py
+++ b/raven/contrib/awslambda/__init__.py
@@ -4,7 +4,7 @@ raven.contrib.awslambda
 
 Raven wrapper for AWS Lambda handlers.
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 # flake8: noqa

--- a/raven/contrib/bottle/utils.py
+++ b/raven/contrib/bottle/utils.py
@@ -2,7 +2,7 @@
 raven.contrib.bottle.utils
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/celery/__init__.py
+++ b/raven/contrib/celery/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.celery
 ~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/django/__init__.py
+++ b/raven/contrib/django/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.django
 ~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/django/celery/__init__.py
+++ b/raven/contrib/django/celery/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.django.celery
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/django/celery/models.py
+++ b/raven/contrib/django/celery/models.py
@@ -2,7 +2,7 @@
 raven.contrib.django.celery.models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/django/celery/tasks.py
+++ b/raven/contrib/django/celery/tasks.py
@@ -2,7 +2,7 @@
 raven.contrib.django.celery.tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -3,7 +3,7 @@
 raven.contrib.django.client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/handlers.py
+++ b/raven/contrib/django/handlers.py
@@ -2,7 +2,7 @@
 raven.contrib.django.handlers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/logging.py
+++ b/raven/contrib/django/logging.py
@@ -2,7 +2,7 @@
 raven.contrib.django.logging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/management/commands/__init__.py
+++ b/raven/contrib/django/management/commands/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.django.management.commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import, print_function

--- a/raven/contrib/django/management/commands/raven.py
+++ b/raven/contrib/django/management/commands/raven.py
@@ -2,7 +2,7 @@
 raven.contrib.django.management.commands.raven
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import, print_function

--- a/raven/contrib/django/middleware/__init__.py
+++ b/raven/contrib/django/middleware/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.django.middleware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/middleware/wsgi.py
+++ b/raven/contrib/django/middleware/wsgi.py
@@ -2,7 +2,7 @@
 raven.contrib.django.middleware.wsgi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/django/models.py
+++ b/raven/contrib/django/models.py
@@ -4,7 +4,7 @@ raven.contrib.django.models
 
 Acts as an implicit hook for Django installs.
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 # flake8: noqa

--- a/raven/contrib/django/raven_compat/__init__.py
+++ b/raven/contrib/django/raven_compat/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.django.raven_compat
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/raven_compat/handlers.py
+++ b/raven/contrib/django/raven_compat/handlers.py
@@ -2,7 +2,7 @@
 raven.contrib.django.raven_compat.handlers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/raven_compat/management/__init__.py
+++ b/raven/contrib/django/raven_compat/management/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.django.raven_compat.management
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import, print_function

--- a/raven/contrib/django/raven_compat/management/commands/__init__.py
+++ b/raven/contrib/django/raven_compat/management/commands/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.django.raven_compat.management.commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import, print_function

--- a/raven/contrib/django/raven_compat/management/commands/raven.py
+++ b/raven/contrib/django/raven_compat/management/commands/raven.py
@@ -2,7 +2,7 @@
 raven.contrib.django.raven_compat.management.commands.raven
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import, print_function

--- a/raven/contrib/django/raven_compat/middleware/__init__.py
+++ b/raven/contrib/django/raven_compat/middleware/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.django.raven_compat.middleware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/raven_compat/middleware/wsgi.py
+++ b/raven/contrib/django/raven_compat/middleware/wsgi.py
@@ -2,7 +2,7 @@
 raven.contrib.django.raven_compat.middleware.wsgi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/raven_compat/models.py
+++ b/raven/contrib/django/raven_compat/models.py
@@ -2,7 +2,7 @@
 raven.contrib.django.raven_compat.models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/raven_compat/templatetags/__init__.py
+++ b/raven/contrib/django/raven_compat/templatetags/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.django.raven_compat.templatetags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/raven_compat/templatetags/raven.py
+++ b/raven/contrib/django/raven_compat/templatetags/raven.py
@@ -2,7 +2,7 @@
 raven.contrib.django.raven_compat.templatetags.raven
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/serializers.py
+++ b/raven/contrib/django/serializers.py
@@ -2,7 +2,7 @@
 raven.contrib.django.serializers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/django/templatetags/__init__.py
+++ b/raven/contrib/django/templatetags/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.django.templatetags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/django/templatetags/raven.py
+++ b/raven/contrib/django/templatetags/raven.py
@@ -2,7 +2,7 @@
 raven.contrib.django.templatetags.raven
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/urls.py
+++ b/raven/contrib/django/urls.py
@@ -2,7 +2,7 @@
 raven.contrib.django.urls
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/django/utils.py
+++ b/raven/contrib/django/utils.py
@@ -2,7 +2,7 @@
 raven.contrib.django.utils
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/django/views.py
+++ b/raven/contrib/django/views.py
@@ -2,7 +2,7 @@
 raven.contrib.django.views
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -2,7 +2,7 @@
 raven.contrib.flask
 ~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/contrib/paste.py
+++ b/raven/contrib/paste.py
@@ -2,7 +2,7 @@
 raven.contrib.paste
 ~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/pylons/__init__.py
+++ b/raven/contrib/pylons/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.pylons
 ~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/webpy/utils.py
+++ b/raven/contrib/webpy/utils.py
@@ -2,7 +2,7 @@
 raven.contrib.webpy.utils
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/zconfig/__init__.py
+++ b/raven/contrib/zconfig/__init__.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 raven.contrib.zconfig
 ~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 import logging

--- a/raven/contrib/zerorpc/__init__.py
+++ b/raven/contrib/zerorpc/__init__.py
@@ -2,7 +2,7 @@
 raven.contrib.zerorpc
 ~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/contrib/zope/__init__.py
+++ b/raven/contrib/zope/__init__.py
@@ -3,7 +3,7 @@
 raven.contrib.zope
 ~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/events.py
+++ b/raven/events.py
@@ -2,7 +2,7 @@
 raven.events
 ~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 
 """

--- a/raven/handlers/__init__.py
+++ b/raven/handlers/__init__.py
@@ -2,7 +2,7 @@
 raven.handlers
 ~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/handlers/logbook.py
+++ b/raven/handlers/logbook.py
@@ -2,7 +2,7 @@
 raven.handlers.logbook
 ~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -2,7 +2,7 @@
 raven.handlers.logging
 ~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/middleware.py
+++ b/raven/middleware.py
@@ -2,7 +2,7 @@
 raven.middleware
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/processors.py
+++ b/raven/processors.py
@@ -2,7 +2,7 @@
 raven.core.processors
 ~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/__init__.py
+++ b/raven/transport/__init__.py
@@ -2,7 +2,7 @@
 raven.transport
 ~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 # TODO: deprecate this namespace and force non-default (sync + threaded) to

--- a/raven/transport/base.py
+++ b/raven/transport/base.py
@@ -2,7 +2,7 @@
 raven.transport.base
 ~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/eventlet.py
+++ b/raven/transport/eventlet.py
@@ -2,7 +2,7 @@
 raven.transport.eventlet
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/exceptions.py
+++ b/raven/transport/exceptions.py
@@ -2,7 +2,7 @@
 raven.transport.exceptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/gevent.py
+++ b/raven/transport/gevent.py
@@ -2,7 +2,7 @@
 raven.transport.gevent
 ~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/http.py
+++ b/raven/transport/http.py
@@ -2,7 +2,7 @@
 raven.transport.http
 ~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/registry.py
+++ b/raven/transport/registry.py
@@ -2,7 +2,7 @@
 raven.transport.registry
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/requests.py
+++ b/raven/transport/requests.py
@@ -2,7 +2,7 @@
 raven.transport.requests
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/threaded.py
+++ b/raven/transport/threaded.py
@@ -2,7 +2,7 @@
 raven.transport.threaded
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/threaded_requests.py
+++ b/raven/transport/threaded_requests.py
@@ -2,7 +2,7 @@
 raven.transport.threaded_requests
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/tornado.py
+++ b/raven/transport/tornado.py
@@ -2,7 +2,7 @@
 raven.transport.tornado
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/transport/twisted.py
+++ b/raven/transport/twisted.py
@@ -2,7 +2,7 @@
 raven.transport.twisted
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -2,7 +2,7 @@
 raven.utils
 ~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/utils/compat.py
+++ b/raven/utils/compat.py
@@ -2,14 +2,14 @@
 raven.utils.compat
 ~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 
 Utilities for writing code that runs on Python 2 and 3
 """
 # flake8: noqa
 
-# Copyright (c) 2010-2013 Benjamin Peterson
+# Copyright (c) 2010-2018 Benjamin Peterson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/raven/utils/encoding.py
+++ b/raven/utils/encoding.py
@@ -2,7 +2,7 @@
 raven.utils.encoding
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import, unicode_literals

--- a/raven/utils/http.py
+++ b/raven/utils/http.py
@@ -2,7 +2,7 @@
 raven.utils.http
 ~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/utils/json.py
+++ b/raven/utils/json.py
@@ -2,7 +2,7 @@
 raven.utils.json
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 

--- a/raven/utils/serializer/__init__.py
+++ b/raven/utils/serializer/__init__.py
@@ -2,7 +2,7 @@
 raven.utils.serializer
 ~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/utils/serializer/base.py
+++ b/raven/utils/serializer/base.py
@@ -3,7 +3,7 @@
 raven.utils.serializer.base
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/utils/serializer/manager.py
+++ b/raven/utils/serializer/manager.py
@@ -2,7 +2,7 @@
 raven.utils.serializer.manager
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import

--- a/raven/utils/stacks.py
+++ b/raven/utils/stacks.py
@@ -2,7 +2,7 @@
 raven.utils.stacks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import, division

--- a/raven/utils/testutils.py
+++ b/raven/utils/testutils.py
@@ -2,7 +2,7 @@
 raven.utils.testutils
 ~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
+:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import


### PR DESCRIPTION
Like @dcramer said, [it's not 2010 any more](https://github.com/getsentry/raven-python/commit/13260b0f5b0e14ce1f3081e5163aaa4f1ee5cec1#diff-f7922c65311be5616a24eea9956f3fe4). This is _super_ pedantic, but it was also bothering the heck out of me. 😁 