### PR TITLE
fix import on Python 2.7

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -22,9 +22,11 @@ from random import Random
 from types import FunctionType
 from threading import local
 
-if sys.version_info >= (3, 2):
+try:
+    # Usually for Python >= 3.2, but some exceptions on 2.7
     import contextlib
-else:
+except ImportError:
+    # Usually for Python < 3.2
     import contextlib2 as contextlib
 
 try:


### PR DESCRIPTION
I started using Raven inside a QGIS plugin : https://github.com/qgis/QGIS

QGIS 2.18 is using Python 2.7 (until QGIS 3 which will come soon with Python 3).

But I had to change the way contextlib is imported in my Python 2.7 environment:

```
import sys
sys.version_info
sys.version_info(major=2, minor=7, micro=10, releaselevel='final', serial=0)
import contextlib2 as contextlib
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/Applications/QGIS.app/Contents/MacOS/../Resources/python/qgis/utils.py", line 607, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
ImportError: No module named contextlib2
import contextlib
```

The last import works perfectly on Python 2.7 on Windows and Mac.