### PR TITLE
Namedtuple Serializer

### DIFF
--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -15,7 +15,9 @@ except ImportError:
 import sys
 
 from raven.utils.compat import iteritems, string_types
-from raven.utils.basic import merge_dicts, varmap, memoize, once
+from raven.utils.basic import (
+    merge_dicts, varmap, memoize, once, is_namedtuple
+)
 
 
 logger = logging.getLogger('raven.errors')

--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -7,51 +7,18 @@ raven.utils
 """
 from __future__ import absolute_import
 
-from raven.utils.compat import iteritems, string_types
 import logging
-import threading
-from functools import update_wrapper
 try:
     import pkg_resources
 except ImportError:
     pkg_resources = None  # NOQA
 import sys
 
+from raven.utils.compat import iteritems, string_types
+from raven.utils.basic import merge_dicts, varmap, memoize, once
+
+
 logger = logging.getLogger('raven.errors')
-
-
-def merge_dicts(*dicts):
-    out = {}
-    for d in dicts:
-        if not d:
-            continue
-
-        for k, v in iteritems(d):
-            out[k] = v
-    return out
-
-
-def varmap(func, var, context=None, name=None):
-    """
-    Executes ``func(key_name, value)`` on all values
-    recurisively discovering dict and list scoped
-    values.
-    """
-    if context is None:
-        context = {}
-    objid = id(var)
-    if objid in context:
-        return func(name, '<...>')
-    context[objid] = 1
-    if isinstance(var, (list, tuple)):
-        ret = [varmap(func, f, context, name) for f in var]
-    else:
-        ret = func(name, var)
-        if isinstance(ret, dict):
-            ret = dict((k, varmap(func, v, context, k))
-                       for k, v in iteritems(var))
-    del context[objid]
-    return ret
 
 
 # We store a cache of module_name->version string to avoid
@@ -144,47 +111,3 @@ def get_auth_header(protocol, timestamp, client, api_key,
         header.append(('sentry_secret', api_secret))
 
     return 'Sentry %s' % ', '.join('%s=%s' % (k, v) for k, v in header)
-
-
-class memoize(object):
-    """
-    Memoize the result of a property call.
-
-    >>> class A(object):
-    >>>     @memoize
-    >>>     def func(self):
-    >>>         return 'foo'
-    """
-
-    def __init__(self, func):
-        self.__name__ = func.__name__
-        self.__module__ = func.__module__
-        self.__doc__ = func.__doc__
-        self.func = func
-
-    def __get__(self, obj, type=None):
-        if obj is None:
-            return self
-        d, n = vars(obj), self.__name__
-        if n not in d:
-            d[n] = self.func(obj)
-        return d[n]
-
-
-def once(func):
-    """Runs a thing once and once only."""
-    lock = threading.Lock()
-
-    def new_func(*args, **kwargs):
-        if new_func.called:
-            return
-        with lock:
-            if new_func.called:
-                return
-            rv = func(*args, **kwargs)
-            new_func.called = True
-            return rv
-
-    new_func = update_wrapper(new_func, func)
-    new_func.called = False
-    return new_func

--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -14,8 +14,9 @@ except ImportError:
     pkg_resources = None  # NOQA
 import sys
 
-from raven.utils.compat import iteritems, string_types
-from raven.utils.basic import (
+# Using "NOQA" to preserve export compatibility
+from raven.utils.compat import iteritems, string_types  # NOQA
+from raven.utils.basic import (  # NOQA
     merge_dicts, varmap, memoize, once, is_namedtuple
 )
 

--- a/raven/utils/basic.py
+++ b/raven/utils/basic.py
@@ -1,0 +1,85 @@
+from __future__ import absolute_import
+
+from functools import update_wrapper
+import threading
+
+from raven.utils.compat import iteritems
+
+
+def merge_dicts(*dicts):
+    out = {}
+    for d in dicts:
+        if not d:
+            continue
+
+        for k, v in iteritems(d):
+            out[k] = v
+    return out
+
+
+def varmap(func, var, context=None, name=None):
+    """
+    Executes ``func(key_name, value)`` on all values
+    recurisively discovering dict and list scoped
+    values.
+    """
+    if context is None:
+        context = {}
+    objid = id(var)
+    if objid in context:
+        return func(name, '<...>')
+    context[objid] = 1
+
+    if isinstance(var, (list, tuple)):
+        ret = [varmap(func, f, context, name) for f in var]
+    else:
+        ret = func(name, var)
+        if isinstance(ret, dict):
+            ret = dict((k, varmap(func, v, context, k))
+                       for k, v in iteritems(var))
+    del context[objid]
+    return ret
+
+
+class memoize(object):
+    """
+    Memoize the result of a property call.
+
+    >>> class A(object):
+    >>>     @memoize
+    >>>     def func(self):
+    >>>         return 'foo'
+    """
+
+    def __init__(self, func):
+        self.__name__ = func.__name__
+        self.__module__ = func.__module__
+        self.__doc__ = func.__doc__
+        self.func = func
+
+    def __get__(self, obj, type=None):
+        if obj is None:
+            return self
+        d, n = vars(obj), self.__name__
+        if n not in d:
+            d[n] = self.func(obj)
+        return d[n]
+
+
+def once(func):
+    """Runs a thing once and once only."""
+    lock = threading.Lock()
+
+    def new_func(*args, **kwargs):
+        if new_func.called:
+            return
+        with lock:
+            if new_func.called:
+                return
+            rv = func(*args, **kwargs)
+            new_func.called = True
+            return rv
+
+    new_func = update_wrapper(new_func, func)
+    new_func.called = False
+    return new_func

--- a/raven/utils/basic.py
+++ b/raven/utils/basic.py
@@ -83,3 +83,14 @@ def once(func):
     new_func = update_wrapper(new_func, func)
     new_func.called = False
     return new_func
+
+
+def is_namedtuple(value):
+    # https://stackoverflow.com/a/2166841/1843746
+    # But modified to handle subclasses of namedtuples.
+    if not isinstance(value, tuple):
+        return False
+    f = getattr(type(value), '_fields', None)
+    if not isinstance(f, tuple):
+        return False
+    return all(type(n) == str for n in f)

--- a/raven/utils/basic.py
+++ b/raven/utils/basic.py
@@ -1,5 +1,11 @@
 from __future__ import absolute_import
 
+try:
+    from collections.abc import Mapping
+except ImportError:
+    # Python < 3.3
+    from collections import Mapping
+
 from functools import update_wrapper
 import threading
 
@@ -30,11 +36,11 @@ def varmap(func, var, context=None, name=None):
         return func(name, '<...>')
     context[objid] = 1
 
-    if isinstance(var, (list, tuple)):
+    if isinstance(var, (list, tuple)) and not is_namedtuple(var):
         ret = [varmap(func, f, context, name) for f in var]
     else:
         ret = func(name, var)
-        if isinstance(ret, dict):
+        if isinstance(ret, Mapping):
             ret = dict((k, varmap(func, v, context, k))
                        for k, v in iteritems(var))
     del context[objid]

--- a/raven/utils/json.py
+++ b/raven/utils/json.py
@@ -9,9 +9,13 @@ raven.utils.json
 from __future__ import absolute_import
 
 import codecs
+import collections
 import datetime
 import uuid
 import json
+
+from .basic import is_namedtuple
+
 
 try:
     JSONDecodeError = json.JSONDecodeError
@@ -25,12 +29,17 @@ class BetterJSONEncoder(json.JSONEncoder):
         datetime.datetime: lambda o: o.strftime('%Y-%m-%dT%H:%M:%SZ'),
         set: list,
         frozenset: list,
-        bytes: lambda o: o.decode('utf-8', errors='replace')
+        bytes: lambda o: o.decode('utf-8', errors='replace'),
+        collections.namedtuple: lambda o: o._asdict(),
     }
 
     def default(self, obj):
+        obj_type = type(obj)
+        if obj_type not in self.ENCODER_BY_TYPE and is_namedtuple(obj):
+            obj_type = collections.namedtuple
+
         try:
-            encoder = self.ENCODER_BY_TYPE[type(obj)]
+            encoder = self.ENCODER_BY_TYPE[obj_type]
         except KeyError:
             try:
                 return super(BetterJSONEncoder, self).default(obj)


### PR DESCRIPTION
Addresses #1079.

I didn't quite grok the situations when the `BetterJSONEncoder` would handle the `namedtuples` vs the `NamedtupleSerializer`, but I updated both just in case---it seems somewhat odd that these two paths exists. So if I'm missing something, please let me know.

I did some recent testing on my end by logging an error and passing parameters that contained namedtuples.  I also passed it through the `extra` kwarg. Note that in order to get it working for the `extra` kwarg, I had to apply b588874.  Things seem to be working, but I think it would be best if someone more  familiar with the code could check this branch out and run the full suite of tests.  I've had similar code running in a production environment for ~3 months.  A few minor changes just now, but the core concept is functional.

