### PR TITLE
logging: Stop mutating record.data

### DIFF
--- a/raven/handlers/logging.py
+++ b/raven/handlers/logging.py
@@ -40,6 +40,9 @@ def extract_extra(record, reserved=RESERVED, contextual=CONTEXTUAL):
             extra = {'data': extra}
         else:
             extra = {}
+    else:
+        # record.data may be something we don't want to mutate to not cause unexpected side effects
+        extra = dict(extra)
 
     for k, v in iteritems(vars(record)):
         if k in reserved:

--- a/tests/handlers/logging/tests.py
+++ b/tests/handlers/logging/tests.py
@@ -119,6 +119,14 @@ class LoggingIntegrationTest(TestCase):
             expected = "u'http://example.com'"
         self.assertEqual(event['extra']['url'], expected)
 
+    def test_extra_data_dict_is_not_mutated(self):
+        # The code used to modify the dictionary included in extra arguments under the 'data' key.
+        # This is unexpected behavior, let's make sure it doesn't happen anymore.
+        data = {'data_key': 'data_value'}
+        record = self.make_record('irrelevant', extra={'data': data})
+        self.handler.emit(record)
+        self.assertEqual(data, {'data_key': 'data_value'})
+
     def test_logger_exc_info(self):
         try:
             raise ValueError('This is a test ValueError')


### PR DESCRIPTION
Without this patch raven's logging handler can't be used with connexion,
because connexion does the following[1]:

     logger.debug('Getting data and status code',
                extra={
                    'data': response,
                    'data_type': type(response),
                    'url': flask.request.url
                })

When response was a dictionary raven would modify it, thus causing
unexpected and unwanted side effects.

[1] https://github.com/zalando/connexion/blob/9f20c5ffb70ccde05193077e677da2a09af362c9/connexion/apis/flask_api.py#L110