### PR TITLE
capture returns the event id directly, not a tuple

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -620,7 +620,7 @@ class Client(object):
         :param stack: a stacktrace for the event
         :param tags: dict of extra tags
         :param sample_rate: a float in the range [0, 1] to sample this message
-        :return: a tuple with a 32-length string identifying this event
+        :return: a 32-length string identifying this event
         """
         if not self.is_enabled():
             return


### PR DESCRIPTION
Correct me if I'm wrong, but the `__doc__` seems incorrect for raven client's `capture`. 