### PR TITLE
[FIX] TypeError on LambdaClient(transport=...)

### DIFF
--- a/raven/contrib/awslambda/__init__.py
+++ b/raven/contrib/awslambda/__init__.py
@@ -54,7 +54,7 @@ class LambdaClient(Client):
     """
 
     def __init__(self, *args, **kwargs):
-        transport = kwargs.get('transport', HTTPTransport)
+        transport = kwargs.pop('transport', HTTPTransport)
         super(LambdaClient, self).__init__(*args, transport=transport, **kwargs)
 
     def capture(self, *args, **kwargs):


### PR DESCRIPTION
Fixes for `TypeError: __init__() got multiple values for keyword argument 'transport'`

The code o LambdaClient would error if `transport` is provided:
```python
>>> LambdaClient(transport='ANYTHING')
Traceback (most recent call last):
  File "<ipython-input-15-12899bb0d00a>", line 1, in <module>
    LambdaClient(transport='ANYTHING')
  File "/Users/alanjds/.virtualenvs/sandbox36/lib/python3.6/site-packages/raven/contrib/awslambda/__init__.py", line 58, in __init__
    super(LambdaClient, self).__init__(*args, transport=transport, **kwargs)
TypeError: __init__() got multiple values for keyword argument 'transport'
```

The culprit is: https://github.com/getsentry/raven-python/blob/2c4ed64beecf9af4b45d4028eae7d540fa8df767/raven/contrib/awslambda/__init__.py#L57

Because it `get()`s instead of `pop()`, `**kwargs` will keeps `transport` kw and will be provided 2 times:
https://github.com/getsentry/raven-python/blob/2c4ed64beecf9af4b45d4028eae7d540fa8df767/raven/contrib/awslambda/__init__.py#L58