### PR TITLE
Add missing closing quote around example in docs

### DIFF
--- a/docs/integrations/logging.rst
+++ b/docs/integrations/logging.rst
@@ -120,7 +120,7 @@ capturing for all messages::
 Passing tags and user context is also available through extra::
 
     logger.error('There was an error, with user context and tags'), extra={
-        'user': {'email': 'test@test.com},
+        'user': {'email': 'test@test.com'},
         'tags': {'database': '1.0'},
     })
 


### PR DESCRIPTION
This pull request just adds a missing closing quote to the `logging.rst` file which is part of the documentation.

Was:  `'user': {'email': 'test@test.com}`
Now:  `'user': {'email': 'test@test.com'}`