### PR TITLE
feat: add extra={'stack': True} support for logbook handler

### DIFF
--- a/docs/integrations/logbook.rst
+++ b/docs/integrations/logbook.rst
@@ -36,3 +36,14 @@ Finally, bind your handler to your context::
     with sentry_handler.applicationbound():
         # everything logged here will go to sentry.
         ...
+
+You can also use the ``extra={'stack': True}`` arguments on
+your ``log`` methods. This will store the appropriate information and allow
+Sentry to render it based on that information::
+
+    # If you don't have an exception, but still want to capture a
+    # stacktrace, use the `stack` arg
+    logger.error('There was an error, with a stacktrace!', extra={
+        'stack': True,
+    })
+

--- a/raven/handlers/logbook.py
+++ b/raven/handlers/logbook.py
@@ -75,6 +75,8 @@ class SentryHandler(logbook.Handler):
 
         if 'tags' in record.kwargs:
             handler_kwargs['tags'] = record.kwargs['tags']
+        if 'stack' in record.extra:
+            handler_kwargs['stack'] = record.extra['stack']
 
         # If there's no exception being processed, exc_info may be a 3-tuple of None
         # http://docs.python.org/library/sys.html#sys.exc_info

--- a/tests/handlers/logbook/tests.py
+++ b/tests/handlers/logbook/tests.py
@@ -71,6 +71,22 @@ class LogbookHandlerTest(TestCase):
             self.assertEquals(msg['message'], 'This is a test info with a url')
             self.assertEquals(msg['params'], ())
 
+            logger.error('This is a test of stacks', extra=dict(
+                stack=True
+            ))
+            self.assertEquals(len(client.events), 1)
+            event = client.events.pop(0)
+            self.assertTrue(event['extra']['stack'])
+            self.assertFalse('exception' in event)
+            self.assertTrue('sentry.interfaces.Message' in event)
+            msg = event['sentry.interfaces.Message']
+            self.assertTrue('stacktrace' in event)
+            frames = event['stacktrace']['frames']
+            self.assertNotEquals(len(frames), 1)
+            frame = frames[0]
+            self.assertEquals(msg['message'], 'This is a test of stacks')
+            self.assertEquals(msg['params'], ())
+
             try:
                 raise ValueError('This is a test ValueError')
             except ValueError:


### PR DESCRIPTION
In logging handler, we can use extra={'stack': True} argument on log method to capture a stack trace, but that argument misses in logbook handler.

```
# If you don't have an exception, but still want to capture a
# stacktrace, use the `stack` arg
logger.error('There was an error, with a stacktrace!', extra={
    'stack': True,
})
```