### PR TITLE
Add blinker to Sanic dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if sys.version_info[0] == 3:
 if sys.version_info >= (3, 5):
     sanic_requires = [
         'blinker>=1.1',
-        'sanic>=0.7.0', 
+        'sanic>=0.7.0',
     ]
     sanic_tests_requires = ['aiohttp', ]
 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,10 @@ if sys.version_info[0] == 3:
 
 # If it's Python 3.5+, add Sanic packages.
 if sys.version_info >= (3, 5):
-    sanic_requires = ['sanic>=0.7.0', ]
+    sanic_requires = [
+        'blinker>=1.1',
+        'sanic>=0.7.0', 
+    ]
     sanic_tests_requires = ['aiohttp', ]
 
 tests_require = [


### PR DESCRIPTION
Pulling 6.7.0 and trying to do, `from raven.contrib.sanic import Sentry`, I get the following traceback:

```python
Traceback (most recent call last):
  File "application.py", line 1, in <module>
    from raven.contrib.sanic import Sentry
  File "/usr/local/lib/python3.6/site-packages/raven/contrib/sanic.py", line 13, in <module>
    import blinker
ModuleNotFoundError: No module named 'blinker'
```

That's my bad. This should resolve that.