### PR TITLE
Lazily import pkg_resources for better import performance.

### DIFF
--- a/raven/utils/__init__.py
+++ b/raven/utils/__init__.py
@@ -8,10 +8,6 @@ raven.utils
 from __future__ import absolute_import
 
 import logging
-try:
-    import pkg_resources
-except ImportError:
-    pkg_resources = None  # NOQA
 import sys
 
 # Using "NOQA" to preserve export compatibility
@@ -32,9 +28,16 @@ _VERSION_CACHE = {}
 def get_version_from_app(module_name, app):
     version = None
 
-    # Try to pull version from pkg_resource first
+    # Try to pull version from pkg_resources first
     # as it is able to detect version tagged with egg_info -b
-    if pkg_resources is not None:
+    try:
+        # Importing pkg_resources can be slow, so only import it
+        # if we need it.
+        import pkg_resources
+    except ImportError:
+        # pkg_resource is not available on Google App Engine
+        pass
+    else:
         # pull version from pkg_resources if distro exists
         try:
             return pkg_resources.get_distribution(module_name).version

--- a/raven/versioning.py
+++ b/raven/versioning.py
@@ -2,12 +2,6 @@ from __future__ import absolute_import
 
 import os.path
 
-try:
-    import pkg_resources
-except ImportError:
-    # pkg_resource is not available on Google App Engine
-    pkg_resources = None
-
 from raven.utils.compat import text_type
 from .exceptions import InvalidGitRepository
 
@@ -68,7 +62,12 @@ def fetch_package_version(dist_name):
     """
     >>> fetch_package_version('sentry')
     """
-    if pkg_resources is None:
+    try:
+        # Importing pkg_resources can be slow, so only import it
+        # if we need it.
+        import pkg_resources
+    except ImportError:
+        # pkg_resource is not available on Google App Engine
         raise NotImplementedError('pkg_resources is not available '
                                   'on this Python install')
     dist = pkg_resources.get_distribution(dist_name)


### PR DESCRIPTION
Initial import performance is a consideration for our application of raven.  We found that we were able more than halve the import time by moving the import of the `pkg_resources` module into the functions that need them.

I believe my changes are covered by existing tests.