### PR TITLE
Fix Django SQL hook

### DIFF
--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -29,7 +29,7 @@ except ImportError:
 
 from raven.base import Client
 from raven.utils.compat import StringIO, iteritems, PY2, string_types, text_type
-from raven.contrib.django.client import DjangoClient
+from raven.contrib.django.client import DjangoClient, record_sql
 from raven.contrib.django.celery import CeleryClient
 from raven.contrib.django.handlers import SentryHandler
 from raven.contrib.django.models import (
@@ -919,3 +919,12 @@ class SentryExceptionHandlerTest(TestCase):
             self.client.ignore_exceptions.clear()
 
         assert not mock_send.called
+
+
+class SQLHookTestCase(TestCase):
+    def test_wrong_params(self):
+        query = 'SELECT COUNT(*) FROM mytestmodel WHERE id = %s'
+        args = ['foobar', 42]
+        record_sql(None, None, None, None, query, args)
+        crumbs = get_client().context.breadcrumbs.get_buffer()
+        self.assertEqual(crumbs[-1]['message'], query)


### PR DESCRIPTION
Hi Guys!

Recently some errors from our code didn't appear in Sentry, but they were in the file log. Turned out if we execute a raw sql query in Django with wrong count of parameters, we will receive an error in DjangoClient `TypeError: not all arguments converted during string formatting` and the original exception will not send to Sentry.

Example of code:

```
with connection.cursor() as cursor:
    cursor.execute('SELECT COUNT(*) FROM games WHERE games.user_id = %s', ['playing', 42])
    count = cursor.fetchone()[0]
```

Related logs:

```
ERROR [sentry.errors.client:214] Unable to process log entry: not all arguments converted during string formatting
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
psycopg2.DataError: invalid input syntax for integer: "playing"
LINE 8:             WHERE (games.user_id = 'playing'...
                                                    ^

The above exception was the direct cause of the following exception:

...

  File "/usr/local/lib/python3.5/site-packages/raven/base.py", line 821, in captureException
    'raven.events.Exception', exc_info=exc_info, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/raven/contrib/django/client.py", line 297, in capture
    result = super(DjangoClient, self).capture(event_type, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/raven/base.py", line 641, in capture
    **kwargs)
  File "/usr/local/lib/python3.5/site-packages/raven/contrib/django/client.py", line 238, in build_msg
    data = super(DjangoClient, self).build_msg(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/raven/base.py", line 500, in build_msg
    crumbs = self.context.breadcrumbs.get_buffer()
  File "/usr/local/lib/python3.5/site-packages/raven/breadcrumbs.py", line 76, in get_buffer
    processor(payload)
  File "/usr/local/lib/python3.5/site-packages/raven/contrib/django/client.py", line 106, in processor
    real_sql = real_sql % tuple(real_params)
TypeError: not all arguments converted during string formatting
```

This PR fix this issue.