### PR TITLE
Include 'user' object in sanitize processing

### DIFF
--- a/raven/processors.py
+++ b/raven/processors.py
@@ -38,6 +38,9 @@ class Processor(object):
         if 'extra' in data:
             data['extra'] = self.filter_extra(data['extra'])
 
+        if 'user' in data:
+            data['user'] = self.filter_user(data['user'])
+
         return data
 
     def filter_stacktrace(self, data):
@@ -47,6 +50,9 @@ class Processor(object):
         pass
 
     def filter_extra(self, data):
+        return data
+
+    def filter_user(self, data):
         return data
 
 
@@ -132,6 +138,9 @@ class SanitizeKeysProcessor(Processor):
                     )
 
     def filter_extra(self, data):
+        return varmap(self.sanitize, data)
+
+    def filter_user(self, data):
         return varmap(self.sanitize, data)
 
     def _sanitize_keyvals(self, keyvals, delimiter):

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -83,6 +83,13 @@ def get_extra_data():
     return data
 
 
+def get_user_data():
+    data = get_extra_data()
+
+    data['user'] = VARS
+    return data
+
+
 class SanitizeKeysProcessorTest(TestCase):
 
     def setUp(self):
@@ -134,6 +141,14 @@ class SanitizeKeysProcessorTest(TestCase):
         self.assertTrue('extra' in result)
         extra = result['extra']
         self._check_vars_sanitized(extra, self.proc.MASK)
+
+    def test_user(self):
+        data = get_user_data()
+        result = self.proc.process(data)
+
+        self.assertTrue('user' in result)
+        user = result['user']
+        self._check_vars_sanitized(user, self.proc.MASK)
 
     def test_querystring_as_string(self):
         data = get_http_data()


### PR DESCRIPTION
This PR includes the 'user' object (as collected by the at least the Django integration) in sanitize processing, which makes it possible to reduce the number of email addresses and user names that leak that way.
