### PR TITLE
feat: switch from culprit to transaction

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -439,8 +439,9 @@ class Client(object):
                         not any(path.startswith(x) for x in self.exclude_paths)
                     )
 
+        transaction = None
         if not culprit:
-            culprit = self.transaction.peek()
+            transaction = self.transaction.peek()
 
         if not data.get('level'):
             data['level'] = kwargs.get('level') or logging.ERROR
@@ -465,7 +466,9 @@ class Client(object):
         if site:
             data['tags'].setdefault('site', site)
 
-        if culprit:
+        if transaction:
+            data['transaction'] = transaction
+        elif culprit:
             data['culprit'] = culprit
 
         if fingerprint:

--- a/tests/contrib/test_celery.py
+++ b/tests/contrib/test_celery.py
@@ -33,7 +33,7 @@ class CeleryTestCase(TestCase):
         assert len(self.client.events) == 1
         event = self.client.events[0]
         exception = event['exception']['values'][-1]
-        assert event['culprit'] == 'dummy_task'
+        assert event['transaction'] == 'dummy_task'
         assert exception['type'] == 'ZeroDivisionError'
 
     def test_ignore_expected(self):


### PR DESCRIPTION
This now sends transactions correctly as transactions and no longer as
culprits.