### PR TITLE
2.0.x add tags to be sanitized also

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include setup.py README.rst MANIFEST.in LICENSE
+include setup.py README.rst MANIFEST.in LICENSE *.txt
 recursive-include raven/contrib/zope *.xml
 global-exclude *~

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ tests_require = open(os.path.join(
 
 setup(
     name='raven',
-    version='2.0.12.1',
+    version='2.0.12.2',
     author='David Cramer',
     author_email='dcramer@gmail.com',
     url='http://github.com/getsentry/raven-python',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ tests_require = open(os.path.join(
 
 setup(
     name='raven',
-    version='2.0.12.2',
+    version='2.0.12.3',
     author='David Cramer',
     author_email='dcramer@gmail.com',
     url='http://github.com/getsentry/raven-python',


### PR DESCRIPTION
Im not sure if it already work and just me, who have problem with that. 

But if I add additional items to be sanitized, it doesn't works for additional tags which a send with the merge function -> client.context.merge({'tags':  "t"}) 

These is two ways how I tried to add additional sanitize_items
1. sanitize_keys = ['_consumer_key', '_consumer_secret', '_access_token', '_access_token_secret'],
or
2. client.module_cache['raven.processors.SanitizePasswordsProcessor'].KEYS = frozenset(['sentry_dsn', 'password', 'passwd', 'access_token', 'secret', 'apikey', 'api_key', 'authorization', '_consumer_key', '_consumer_secret', '_access_token', '_access_token_secret'])

And unfortunately those keys are still send to the server in the bunch of tags.

U would really happy to your responce=)

Sunny Week
Egor 
