### PR TITLE
Default usage of raven.Client does not import twisted or requests

### DIFF
--- a/raven/conf/remote.py
+++ b/raven/conf/remote.py
@@ -33,9 +33,6 @@ def discover_default_transport():
     return ThreadedHTTPTransport
 
 
-DEFAULT_TRANSPORT = discover_default_transport()
-
-
 class RemoteConfig(object):
     def __init__(self, base_url=None, project=None, public_key=None,
                  secret_key=None, transport=None, options=None):
@@ -52,7 +49,7 @@ class RemoteConfig(object):
         self.options = options or {}
         self.store_endpoint = store_endpoint
 
-        self._transport_cls = transport or DEFAULT_TRANSPORT
+        self._transport_cls = transport or discover_default_transport()
 
     def __unicode__(self):
         return text_type(self.base_url)

--- a/raven/transport/requests.py
+++ b/raven/transport/requests.py
@@ -33,4 +33,4 @@ class RequestsHTTPTransport(HTTPTransport):
             # perform the verification.
             self.verify_ssl = self.ca_certs
         requests.post(url, data=data, headers=headers,
-                      verify=self.verify_ssl, timeout=self.timeout)
+                verify=self.verify_ssl, timeout=self.timeout)

--- a/raven/transport/requests.py
+++ b/raven/transport/requests.py
@@ -9,24 +9,25 @@ from __future__ import absolute_import
 
 from raven.transport.http import HTTPTransport
 
-try:
-    import requests
-    has_requests = True
-except ImportError:
-    has_requests = False
-
 
 class RequestsHTTPTransport(HTTPTransport):
 
     scheme = ['requests+http', 'requests+https']
 
     def __init__(self, *args, **kwargs):
+        try:
+            import requests # NOQA
+            has_requests = True
+        except ImportError:
+            has_requests = False
+
         if not has_requests:
             raise ImportError('RequestsHTTPTransport requires requests.')
 
         super(RequestsHTTPTransport, self).__init__(*args, **kwargs)
 
     def send(self, url, data, headers):
+        import requests
         if self.verify_ssl:
             # If SSL verification is enabled use the provided CA bundle to
             # perform the verification.

--- a/tests/breadcrumbs/tests.py
+++ b/tests/breadcrumbs/tests.py
@@ -187,6 +187,8 @@ class BreadcrumbTestCase(TestCase):
             crumbs = client.context.breadcrumbs.get_buffer()
             assert 'dummy' not in set([i['type'] for i in crumbs])
 
+        # pretend 'dummy' is a module, and is already loaded
+        sys.modules['dummy'] = None
         client = Client('http://foo:bar@example.com/0', hook_libraries=['requests', 'dummy'])
         with client.context:
             DummyClass().dummy_method()

--- a/tests/transport/requests/test_threaded_requests.py
+++ b/tests/transport/requests/test_threaded_requests.py
@@ -1,5 +1,8 @@
 import mock
 import time
+
+import requests
+
 from raven.utils.testutils import TestCase
 
 from raven.base import Client
@@ -26,7 +29,7 @@ class ThreadedTransportTest(TestCase):
         self.url = "threaded+requests+http://some_username:some_password@localhost:8143/1"
         self.client = Client(dsn=self.url)
 
-    @mock.patch('raven.transport.requests.post')
+    @mock.patch('requests.post')
     def test_does_send(self, send):
         self.client.captureMessage(message='foo')
 

--- a/tests/transport/requests/tests.py
+++ b/tests/transport/requests/tests.py
@@ -4,6 +4,7 @@ import mock
 
 from raven.utils.testutils import TestCase
 from raven.base import Client
+import requests
 
 
 class RequestsTransportTest(TestCase):
@@ -12,7 +13,7 @@ class RequestsTransportTest(TestCase):
             dsn="requests+http://some_username:some_password@localhost:8143/1",
         )
 
-    @mock.patch('raven.transport.requests.post')
+    @mock.patch('requests.post')
     def test_does_send(self, post):
         self.client.captureMessage(message='foo')
         self.assertEqual(post.call_count, 1)


### PR DESCRIPTION
This patch addresses #1258 by taking steps to lazily load the requests and twisted modules.

Summary of changes:
* Delay the `hook_libraries` function if the module requested hasn't been loaded yet.
* Remove and instead lazy load DEFAULT_TRANSPORT (wasn't used outside its .py).
* Remove the default loading of `twisted` and `requests` in their respective transport subclasses.  Lazy load what's needed.

Caveats:
* While I modified existing tests to pass, I was not sure how to write a unit test for this, as performance tests can be tricky.
* While this should work in all supported pythons, I'm only able to run the tests in latest 2- and 3- series.