### PR TITLE
Add SemVer stability badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,9 @@ Raven - Sentry for Python
    :target: https://codeclimate.com/github/getsentry/raven-python
    :alt: Code Climate
 
+.. image:: https://api.dependabot.com/badges/compatibility_score?dependency-name=raven&package-manager=pip&version-scheme=semver
+    :target: https://dependabot.com/compatibility-score.html?dependency-name=raven&package-manager=pip&version-scheme=semver
+
 
 Raven is the official Python client for `Sentry`_, officially supports
 Python 2.6–2.7 & 3.3–3.7, and runs on PyPy and Google App Engine.


### PR DESCRIPTION
Adds a SemVer stability badge that displays the percentage of CI runs that pass when updating raven between SemVer compatible versions. Data comes from update runs that Dependabot has done for sentry users (disclosure: I built it).

Here's what the badge looks like:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=raven&package-manager=pip&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=raven&package-manager=pip&version-scheme=semver)

I put together an [equivalent PR](https://github.com/getsentry/raven-ruby/pull/848) for the ruby gem and the folks there really liked it, so thought I'd put one together for Python, too. :octocat: 