### PR TITLE
Make send method of threaded transports overridable

### DIFF
--- a/raven/transport/threaded.py
+++ b/raven/transport/threaded.py
@@ -151,10 +151,7 @@ class AsyncWorker(object):
             sleep(0)
 
 
-class ThreadedHTTPTransport(AsyncTransport, HTTPTransport):
-
-    scheme = ['http', 'https', 'threaded+http', 'threaded+https']
-
+class ThreadedTransport(AsyncTransport):
     def get_worker(self):
         if not hasattr(self, '_worker') or not self._worker.is_alive():
             self._worker = AsyncWorker()
@@ -171,3 +168,7 @@ class ThreadedHTTPTransport(AsyncTransport, HTTPTransport):
     def async_send(self, url, data, headers, success_cb, failure_cb):
         self.get_worker().queue(
             self.send_sync, url, data, headers, success_cb, failure_cb)
+
+
+class ThreadedHTTPTransport(HTTPTransport, ThreadedTransport):
+    scheme = ['http', 'https', 'threaded+http', 'threaded+https']

--- a/raven/transport/threaded.py
+++ b/raven/transport/threaded.py
@@ -162,7 +162,7 @@ class ThreadedHTTPTransport(AsyncTransport, HTTPTransport):
 
     def send_sync(self, url, data, headers, success_cb, failure_cb):
         try:
-            super(ThreadedHTTPTransport, self).send(url, data, headers)
+            self.send(url, data, headers)
         except Exception as e:
             failure_cb(e)
         else:

--- a/raven/transport/threaded_requests.py
+++ b/raven/transport/threaded_requests.py
@@ -23,7 +23,7 @@ class ThreadedRequestsHTTPTransport(AsyncTransport, RequestsHTTPTransport):
 
     def send_sync(self, url, data, headers, success_cb, failure_cb):
         try:
-            super(ThreadedRequestsHTTPTransport, self).send(url, data, headers)
+            self.send(url, data, headers)
         except Exception as e:
             failure_cb(e)
         else:

--- a/raven/transport/threaded_requests.py
+++ b/raven/transport/threaded_requests.py
@@ -7,28 +7,9 @@ raven.transport.threaded_requests
 """
 from __future__ import absolute_import
 
-from raven.transport.base import AsyncTransport
 from raven.transport import RequestsHTTPTransport
-from raven.transport.threaded import AsyncWorker
+from raven.transport.threaded import ThreadedTransport
 
 
-class ThreadedRequestsHTTPTransport(AsyncTransport, RequestsHTTPTransport):
-
+class ThreadedRequestsHTTPTransport(RequestsHTTPTransport, ThreadedTransport):
     scheme = ['threaded+requests+http', 'threaded+requests+https']
-
-    def get_worker(self):
-        if not hasattr(self, '_worker'):
-            self._worker = AsyncWorker()
-        return self._worker
-
-    def send_sync(self, url, data, headers, success_cb, failure_cb):
-        try:
-            self.send(url, data, headers)
-        except Exception as e:
-            failure_cb(e)
-        else:
-            success_cb()
-
-    def async_send(self, url, data, headers, success_cb, failure_cb):
-        self.get_worker().queue(
-            self.send_sync, url, data, headers, success_cb, failure_cb)


### PR DESCRIPTION
This change introduces two things:
* Make the `send()` method of `ThreadedHTTPTransport` and `ThreadedRequestsHTTPTransport` overridable.
* Add a new base class to unify all threaded transports. Previously both implementations were almost the same.