### PR TITLE
Ensure that all keys in locals are strings before serializing

### DIFF
--- a/raven/utils/stacks.py
+++ b/raven/utils/stacks.py
@@ -14,8 +14,7 @@ import os
 import sys
 
 from raven.utils.serializer import transform
-from raven.utils.compat import iteritems
-
+from raven.utils.compat import iteritems, string_types
 
 _coding_re = re.compile(r'coding[:=]\s*([-\w.]+)')
 
@@ -156,6 +155,9 @@ def get_frame_locals(frame, transformer=transform, max_var_size=4096):
     f_vars = {}
     f_size = 0
     for k, v in iteritems(f_locals):
+        # Trio (and maybe others) insert non string keys into f_locals
+        if not isinstance(k, string_types):
+            k = repr(k)
         v = transformer(v)
         v_size = len(repr(v))
         if v_size + f_size < max_var_size:


### PR DESCRIPTION
Trio uses an ugly hack and puts a value into locals with a
non string key (class LOCALS_KI_PROTECTION_ENABLED).

When trying to serialize that, JsonEncoder crashes.
So we ensure that every key is indeed a string.

Another way to solve this problem would be to pass skipkeys=True
to json.dumps, but this might mask other errors.