### PR TITLE
Update processors.py

### DIFF
--- a/raven/processors.py
+++ b/raven/processors.py
@@ -162,7 +162,7 @@ class SanitizePasswordsProcessor(SanitizeKeysProcessor):
         'sentry_dsn',
         'access_token',
     ])
-    VALUES_RE = re.compile(r'^(?:\d[ -]*?){13,16}$')
+    VALUES_RE = re.compile(r'^\'?(?:\d[ -]*?){13,16}\'?$')
 
     @property
     def sanitize_keys(self):

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -367,6 +367,11 @@ class SanitizePasswordsProcessorTest(TestCase):
         result = proc.sanitize('foo', '424242424242424')
         self.assertEquals(result, proc.MASK)
 
+    def test_sanitize_credit_card_in_stack_local(self):
+        proc = SanitizePasswordsProcessor(Mock())
+        result = proc.sanitize('foo', "'424242424242424'")
+        self.assertEquals(result, proc.MASK)
+
     def test_sanitize_non_ascii(self):
         proc = SanitizePasswordsProcessor(Mock())
         result = proc.sanitize('__repr__: жили-были', '42')


### PR DESCRIPTION
Current regex does not match against credit card numbers in the stack local values, because they are wrapped in single quotes: `'4242424242424242'`. It could be that credit card numbers should always be represented as integers, but it seems harmless to catch this case as well.

Fixes #1253
