### PR TITLE
Support longer credit card numbers, upto and including 19 digits.

### DIFF
--- a/raven/processors.py
+++ b/raven/processors.py
@@ -162,7 +162,7 @@ class SanitizePasswordsProcessor(SanitizeKeysProcessor):
         'sentry_dsn',
         'access_token',
     ])
-    VALUES_RE = re.compile(r'^(?:\d[ -]*?){13,16}$')
+    VALUES_RE = re.compile(r'^(?:\d[ -]*?){13,19}$')
 
     @property
     def sanitize_keys(self):

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -367,6 +367,12 @@ class SanitizePasswordsProcessorTest(TestCase):
         result = proc.sanitize('foo', '424242424242424')
         self.assertEquals(result, proc.MASK)
 
+    def test_sanitize_credit_card_long(self):
+        # Credit card numbers can be 19 digits long
+        proc = SanitizePasswordsProcessor(Mock())
+        result = proc.sanitize('foo', '1234567890123456789')
+        self.assertEquals(result, proc.MASK)
+
     def test_sanitize_non_ascii(self):
         proc = SanitizePasswordsProcessor(Mock())
         result = proc.sanitize('__repr__: жили-были', '42')

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -373,6 +373,24 @@ class SanitizePasswordsProcessorTest(TestCase):
         result = proc.sanitize('foo', '1234567890123456789')
         self.assertEquals(result, proc.MASK)
 
+    def test_sanitize_credit_card_with_spaces_and_dashes(self):
+        # Credit card numbers may contain spaces and dashes
+        proc = SanitizePasswordsProcessor(Mock())
+        result = proc.sanitize('foo', '1234 5678 9012-3456-789')
+        self.assertEquals(result, proc.MASK)
+
+    def test_sanitize_ignores_too_long_number(self):
+        # Not a credit card number because it is longer than 19 digits
+        proc = SanitizePasswordsProcessor(Mock())
+        result = proc.sanitize('foo', '12345678901234567890')
+        self.assertEquals(result, '12345678901234567890')
+
+    def test_sanitize_ignores_too_short_number(self):
+        # Not a credit card number because it is shorter than 13 digits
+        proc = SanitizePasswordsProcessor(Mock())
+        result = proc.sanitize('foo', '123456789012')
+        self.assertEquals(result, '123456789012')
+
     def test_sanitize_non_ascii(self):
         proc = SanitizePasswordsProcessor(Mock())
         result = proc.sanitize('__repr__: жили-были', '42')


### PR DESCRIPTION
According to multiple sources credit cards can now be 19 digits long.

- https://www.mastercard.us/content/dam/mccom/global/documents/mastercard-rules.pdf
    > For a Maestro Account, the PAN must be 13 to 19 digits in length.
- https://www.freeformatter.com/credit-card-number-generator-validator.html
- https://en.wikipedia.org/wiki/Payment_card_number
