### PR TITLE
chore(deprecation): fix collections.abc imports

### DIFF
--- a/raven/breadcrumbs.py
+++ b/raven/breadcrumbs.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import
 
-import collections
 import os
 import logging
 
+try:
+    from collections.abc import Mapping
+except ImportError:
+    # Python < 3.3
+    from collections import Mapping
 from time import time
 from types import FunctionType
 
@@ -140,7 +144,7 @@ def _record_log_breadcrumb(logger, level, msg, *args, **kwargs):
         data_value = kwargs
         data_value.update(extra)
 
-        if args and len(args) == 1 and isinstance(args[0], collections.Mapping) and args[0]:
+        if args and len(args) == 1 and isinstance(args[0], Mapping) and args[0]:
             format_args = args[0]
             data_value.update(format_args)
 

--- a/raven/context.py
+++ b/raven/context.py
@@ -7,7 +7,11 @@ raven.context
 """
 from __future__ import absolute_import
 
-from collections import Mapping, Iterable
+try:
+    from collections.abc import Mapping, Iterable
+except ImportError:
+    # Python < 3.3
+    from collections import Mapping, Iterable
 from threading import local
 from weakref import ref as weakref
 


### PR DESCRIPTION
As of Python 3.7, importing ABCs directly from collections has been
deprecated.

> DeprecationWarning: Using or importing the ABCs from 'collections'
> instead of from 'collections.abc' is deprecated, and in 3.8 it
> will stop working.