### PR TITLE
setup.py: add extra target for Sanic dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
     zip_safe=False,
     extras_require={
         'flask': flask_requires,
+        'sanic': sanic_requires,
         'tests': tests_require,
         ':python_version<"3.2"': ['contextlib2'],
     },


### PR DESCRIPTION
This ensures that someone installing sanic support will get the blinker dependency as well

See #1005 