### PR TITLE
Use correct kwarg in handle_exception() for Flask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ------
 
 * [Core] Fixed stackframes in some situations being in inverse order.
+* [Flask] Fix wrong exception handling logic (accidentally relied on Flask internals).
 
 6.9.0 (2018-05-30)
 ------------------

--- a/raven/contrib/flask.py
+++ b/raven/contrib/flask.py
@@ -136,7 +136,16 @@ class Sentry(object):
         if not self.client:
             return
 
-        self.captureException(exc_info=kwargs.get('exc_info'))
+        # got_request_exception signal passes the exception as 'exception'
+        exception = kwargs.get('exception')
+        if exception is not None and hasattr(exception, '__traceback__'):
+            # On Python 3 we can contruct the exc_info via __traceback__
+            exc_info = (type(exception), exception, exception.__traceback__)
+        else:
+            # The user may call the method with 'exc_info' manually
+            exc_info = kwargs.get('exc_info')
+
+        self.captureException(exc_info=exc_info)
 
     def get_user_info(self, request):
         """


### PR DESCRIPTION
The handle_exception() method is registered as a receiver of the
got_request_exception signal. According to both the [documentation][1]
and [source code][2] of Flask the got_request_exception signal passes
the exception as `exception` rather than a `exc_info`.

This is likely to have gone unnoticed since captureException() calls
sys.exc_info() in the absence of an exception.

On Python 3 we can use `__traceback__` to explicitly construct the
`exc_info`.

[1]: http://flask.pocoo.org/docs/1.0/api/#flask.got_request_exception
[2]: https://github.com/pallets/flask/blob/1.0.2/flask/app.py#L1732