### PR TITLE
remove docs link to nowhere

### DIFF
--- a/hooks/pre-commit.verify-docs
+++ b/hooks/pre-commit.verify-docs
@@ -1,1 +1,0 @@
-../docs/_sentryext/verify-docs.py


### PR DESCRIPTION
With ea000f57b6f249974293003e97b84741323fadf5 docs folder was removed, therefore the pre-commit hook should go to.