### PR TITLE
Allow `extra` to be None in breadcrumbs processing

### DIFF
--- a/raven/breadcrumbs.py
+++ b/raven/breadcrumbs.py
@@ -141,6 +141,8 @@ def _record_log_breadcrumb(logger, level, msg, *args, **kwargs):
 
         # Extract 'extra' key from kwargs and merge into data
         extra = kwargs.pop('extra', {})
+        if extra is None:
+            extra = {}
         data_value = kwargs
         data_value.update(extra)
 

--- a/tests/breadcrumbs/tests.py
+++ b/tests/breadcrumbs/tests.py
@@ -53,6 +53,17 @@ class BreadcrumbTestCase(TestCase):
         assert crumbs[0]['data'] == {'foo': 'bar', 'blah': 'baz'}
         assert crumbs[0]['message'] == 'This is a message with bar!'
 
+    def test_log_crumb_reporting_with_dict_extra_none(self):
+        """Don't raise an exception if extra is None"""
+        client = Client('http://foo:bar@example.com/0')
+        with client.context:
+            log = logging.getLogger('whatever.foo')
+            log.info('This is a message with %(foo)s!', {'foo': 'bar'},
+                     extra=None)
+            crumbs = client.context.breadcrumbs.get_buffer()
+
+        assert len(crumbs) == 1
+
     def test_log_crumb_reporting_with_large_message(self):
         client = Client('http://foo:bar@example.com/0')
         with client.context:


### PR DESCRIPTION
Sometimes, `extra` is passed in as a default parameter of another
function and can therefore be `None`. This fixes:

	Traceback (most recent call last):
	  File "raven/breadcrumbs.py", line 77, in get_buffer
		processor(payload)
	  File "raven/breadcrumbs.py", line 143, in processor
		data_value.update(extra)
	TypeError: 'NoneType' object is not iterable