### PR TITLE
fix: Dont serialize nan when present in frame local vars

### DIFF
--- a/raven/utils/serializer/base.py
+++ b/raven/utils/serializer/base.py
@@ -174,17 +174,8 @@ class FloatSerializer(Serializer):
     types = (float,)
 
     def serialize(self, value, **kwargs):
-        value = float(value)
-
-        if value == float('inf'):
-            return '<inf>'
-        if value == float('-inf'):
-            return '<-inf>'
-        # lol checking for float('nan')
-        if value != value:
-            return '<nan>'
-
-        return value
+        # Wrap with repr to convert inf/nan to string
+        return repr(float(value))
 
 
 class IntegerSerializer(Serializer):

--- a/raven/utils/serializer/base.py
+++ b/raven/utils/serializer/base.py
@@ -174,7 +174,17 @@ class FloatSerializer(Serializer):
     types = (float,)
 
     def serialize(self, value, **kwargs):
-        return float(value)
+        value = float(value)
+
+        if value == float('inf'):
+            return '<inf>'
+        if value == float('-inf'):
+            return '<-inf>'
+        # lol checking for float('nan')
+        if value != value:
+            return '<nan>'
+
+        return value
 
 
 class IntegerSerializer(Serializer):

--- a/raven/utils/serializer/base.py
+++ b/raven/utils/serializer/base.py
@@ -167,7 +167,7 @@ class BooleanSerializer(Serializer):
     types = (bool,)
 
     def serialize(self, value, **kwargs):
-        return bool(value)
+        return repr(bool(value))
 
 
 class FloatSerializer(Serializer):
@@ -182,7 +182,7 @@ class IntegerSerializer(Serializer):
     types = (int,)
 
     def serialize(self, value, **kwargs):
-        return int(value)
+        return repr(int(value))
 
 
 class FunctionSerializer(Serializer):
@@ -198,7 +198,7 @@ if PY2:
         types = (long,)  # noqa
 
         def serialize(self, value, **kwargs):
-            return long(value)  # noqa
+            return repr(long(value))  # noqa
 
 
 # register all serializers, order matters

--- a/tests/base/tests.py
+++ b/tests/base/tests.py
@@ -317,7 +317,7 @@ class ClientTest(TestCase):
         event, = self.client.events
         exc, = event['exception']['values']
         frame, = exc['stacktrace']['frames']
-        assert frame['vars']['foo'] == "<nan>"
+        assert frame['vars']['foo'] == "nan"
 
     def test_exception_event_true_exc_info(self):
         try:

--- a/tests/base/tests.py
+++ b/tests/base/tests.py
@@ -307,6 +307,18 @@ class ClientTest(TestCase):
         self.assertEquals(frame['function'], 'test_exception_event')
         self.assertTrue('timestamp' in event)
 
+    def test_exception_nan_in_vars(self):
+        try:
+            foo = float("nan")  # noqa
+            raise ValueError("foo")
+        except ValueError:
+            self.client.captureException()
+
+        event, = self.client.events
+        exc, = event['exception']['values']
+        frame, = exc['stacktrace']['frames']
+        assert frame['vars']['foo'] == "<nan>"
+
     def test_exception_event_true_exc_info(self):
         try:
             raise ValueError('foo')

--- a/tests/utils/encoding/tests.py
+++ b/tests/utils/encoding/tests.py
@@ -65,8 +65,7 @@ class TransformTest(TestCase):
 
     def test_float(self):
         result = transform(13.0)
-        self.assertEqual(type(result), float)
-        self.assertEqual(result, 13.0)
+        self.assertEqual(result, "13.0")
 
     def test_bool(self):
         result = transform(True)

--- a/tests/utils/encoding/tests.py
+++ b/tests/utils/encoding/tests.py
@@ -69,16 +69,14 @@ class TransformTest(TestCase):
 
     def test_bool(self):
         result = transform(True)
-        self.assertEqual(type(result), bool)
-        self.assertEqual(result, True)
+        self.assertEqual(result, 'True')
 
     def test_int_subclass(self):
         class X(int):
             pass
 
         result = transform(X())
-        self.assertEqual(type(result), int)
-        self.assertEqual(result, 0)
+        self.assertEqual(result, '0')
 
     def test_dict_keys(self):
         x = {'foo': 'bar'}
@@ -175,7 +173,7 @@ class TransformTest(TestCase):
     def test_list_max_length(self):
         x = list(range(10))
         result = transform(x, list_max_length=3)
-        self.assertEqual(result, (0, 1, 2))
+        self.assertEqual(result, ('0', '1', '2'))
 
     def test_dict_max_length(self):
         x = dict((x, x) for x in range(10))


### PR DESCRIPTION
We want to use Rust on the server to decode JSON and it's not possible to just hook into there and add support for new constants (essentially new syntax) without forking the JSON library or running some code before deserializing.

The exact values are how `frame.vars` are coerced on the server anyway so there is no difference in display to the user.

Raven still permits sending NaN as part of other variables. Sentry-sdk (in master) treats it like any unserializable value. Serverside this is converted to `None` while deserializing.

Not sure if coercing to string would be that great (might create new groups) or if we should rather just crash in the SDK like sentry-sdk does now and drop the event.