### PR TITLE
feat: auto log exc info

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -177,6 +177,8 @@ class Client(object):
             o.get('machine') or defaults.NAME)
         self.auto_log_stacks = bool(
             o.get('auto_log_stacks') or defaults.AUTO_LOG_STACKS)
+        self.auto_log_exc_info = bool(
+            o.get('auto_log_exc_info') or defaults.AUTO_LOG_EXC_INFO)
         self.capture_locals = bool(
             o.get('capture_locals', defaults.CAPTURE_LOCALS))
         self.string_max_length = int(
@@ -387,6 +389,13 @@ class Client(object):
         if '.' not in event_type:
             # Assume it's a builtin
             event_type = 'raven.events.%s' % event_type
+
+        if (stack is None and event_type == 'raven.events.Message'
+                and self.auto_log_exc_info):
+            exc_info = sys.exc_info()
+            if exc_info and exc_info[0] is not None:
+                kwargs['exc_info'] = exc_info
+                event_type = 'raven.events.Exception'
 
         handler = self.get_handler(event_type)
         result = handler.capture(**kwargs)

--- a/raven/conf/defaults.py
+++ b/raven/conf/defaults.py
@@ -34,6 +34,9 @@ MAX_LENGTH_STRING = 400
 # Automatically log frame stacks from all ``logging`` messages.
 AUTO_LOG_STACKS = False
 
+# Automatically log exc info from all ``logging`` messages.
+AUTO_LOG_EXC_INFO = False
+
 # Collect locals variables
 CAPTURE_LOCALS = True
 

--- a/raven/utils/conf.py
+++ b/raven/utils/conf.py
@@ -42,6 +42,7 @@ def convert_options(settings, defaults=None):
     options.setdefault('timeout', getopt('timeout'))
     options.setdefault('name', getopt('name'))
     options.setdefault('auto_log_stacks', getopt('auto_log_stacks'))
+    options.setdefault('auto_log_exc_info', getopt('auto_log_exc_info'))
     options.setdefault('string_max_length', getopt('string_max_length'))
     options.setdefault('list_max_length', getopt('list_max_length'))
     options.setdefault('site', getopt('site'))


### PR DESCRIPTION
This PR adds an enhanced version of `auto_log_stacks`: `auto_log_exc_info`.

An incoming `Message` event may be upgraded to an `Exception` event in case there is a recent stack trace.

Take this truncated snippet from a [downstream test suite](https://github.com/das7pad/hangoutsbot/blob/9c350b9a1271ea7c73384b132212026a301345a4/tests/test_plugins/test_sentry.py#L182):

```python3
def raise_key_error(key):
    return {}[key]

try:
    raise_key_error('key of test_stack_from_error')
except KeyError:
    logger.error('desc of test_stack_from_error')
```
- With the `auto_log_stacks` option enabled, raven would submit the full stack trace from inside the raven-logic via the logger internals to the actual logger call and then to the entry point.
  ![stack in sentry 9.0.0](https://user-images.githubusercontent.com/17931887/50155136-88e77e80-02cb-11e9-8143-8d6e72a84a25.png)

- With the new `auto_log_exc_info` option enabled, raven would submit the actual trace back.
  ![trace back in sentry 9.0.0](https://user-images.githubusercontent.com/17931887/50155189-b16f7880-02cb-11e9-8120-28d5089587fd.png)



