### PR TITLE
fix: handle an existent but empty exc_info

### DIFF
--- a/raven/base.py
+++ b/raven/base.py
@@ -631,7 +631,7 @@ class Client(object):
             return
 
         exc_info = kwargs.get('exc_info')
-        if exc_info is not None:
+        if exc_info is not None and exc_info[0] is not None:
             if self.skip_error_for_logging(exc_info):
                 return
             elif not self.should_capture(exc_info):

--- a/raven/events.py
+++ b/raven/events.py
@@ -113,7 +113,7 @@ class Exception(BaseEvent):
         if not exc_info or exc_info is True:
             exc_info = sys.exc_info()
 
-        if not exc_info:
+        if not exc_info or exc_info[0] is None:
             raise ValueError('No exception found')
 
         values = []

--- a/tests/base/tests.py
+++ b/tests/base/tests.py
@@ -337,6 +337,16 @@ class ClientTest(TestCase):
         self.assertEquals(frame['filename'], 'tests/base/tests.py')
         self.assertEquals(frame['module'], __name__)
 
+    def test_exception_event_no_exc_info(self):
+        with self.assertRaisesRegex(ValueError, 'No exception found'):
+            self.client.captureException()
+
+    def test_exception_event_empty_exc_info(self):
+        exc_info = sys.exc_info()
+        self.assertEquals(exc_info, (None, None, None))
+        with self.assertRaisesRegex(ValueError, 'No exception found'):
+            self.client.captureException(exc_info=exc_info)
+
     def test_exception_event_ignore_string(self):
         class Foo(Exception):
             pass


### PR DESCRIPTION
In case there is no raised exception in the trace, all exc_info fields are None.

```python
>>> sys.exc_info()
(None, None, None)
```

A traceback from an invalid object access on the exc_info members is not useful for debugging.
Instead we should reach the logic to reject the exception with a ValueError.

https://github.com/getsentry/raven-python/blob/34c3a52b13316ce3200e56978ff01a277f33d27a/raven/events.py#L116-L117